### PR TITLE
feat(logging): Log SDK version during initialization

### DIFF
--- a/wujihandcpp/CMakeLists.txt
+++ b/wujihandcpp/CMakeLists.txt
@@ -12,7 +12,7 @@ execute_process(
 )
 
 # Extract version number if tag format is valid
-if(GIT_TAG_RESULT EQUAL 0 AND GIT_TAG MATCHES "^v([0-9]+\\.[0-9]+\\.[0-9]+)$")
+if(GIT_TAG_RESULT EQUAL 0 AND GIT_TAG MATCHES "^v.+$")
     string(REGEX REPLACE "^v" "" PROJECT_VERSION ${GIT_TAG})
     message(STATUS "Using Git tag version: ${PROJECT_VERSION}")
 else()
@@ -78,6 +78,7 @@ else()
 endif()
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE BUILDING_WUJIHANDCPP)
+target_compile_definitions(${PROJECT_NAME} PUBLIC WUJIHANDCPP_VERSION="${PROJECT_VERSION}")
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)

--- a/wujihandcpp/src/logging/logging.hpp
+++ b/wujihandcpp/src/logging/logging.hpp
@@ -361,6 +361,8 @@ private:
             logger_->set_level(to_spdlog_level(config.log_level()));
             logger_->flush_on(spdlog::level::warn);
 
+            logger_->info("SDK v{} initialized", WUJIHANDCPP_VERSION);
+
             if (log_path_error.empty()) {
                 if (config.log_to_file())
                     logger_->info("Log files can be found at {}", log_path.string());


### PR DESCRIPTION
Resolve m-6471233308

## 自测

SDK 启动时，输出：
```
[2025-11-20 02:04:55.056] [wuji] [info] SDK v1.3.0a0 initialized
[2025-11-20 02:04:55.056] [wuji] [info] Log files can be found at /home/ubuntu/.wuji/log/20251120_020455_20167.log
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 初始化过程中自动记录并输出 SDK 版本信息
  * 项目版本号已公开为库使用者提供
  * 版本标记检测模式更加灵活，现支持所有以 'v' 开头的标记格式

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->