### PR TITLE
feat: Support firmware-side realtime filtering

### DIFF
--- a/src/controller.hpp
+++ b/src/controller.hpp
@@ -13,86 +13,51 @@
 
 namespace py = pybind11;
 
-class IController {
+class IControllerWrapper final {
 public:
-    IController() = default;
+    explicit IControllerWrapper(std::unique_ptr<wujihandcpp::device::IController> controller)
+        : controller_(std::move(controller)) {}
 
-    IController(const IController&) = delete;
-    IController& operator=(const IController&) = delete;
-    IController(IController&&) = delete;
-    IController& operator=(IController&&) = delete;
+    IControllerWrapper(const IControllerWrapper&) = delete;
+    IControllerWrapper& operator=(const IControllerWrapper&) = delete;
+    IControllerWrapper(IControllerWrapper&&) noexcept = default;
+    IControllerWrapper& operator=(IControllerWrapper&&) noexcept = default;
 
-    virtual ~IController() = default;
+    ~IControllerWrapper() = default;
 
-    virtual py::array_t<double> get_joint_actual_position() = 0;
+    py::array_t<double> get_joint_actual_position() {
+        if (!controller_)
+            throw std::runtime_error("Controller is closed.");
 
-    virtual void set_joint_target_position(const py::array_t<double>&) = 0;
+        const auto& positions = controller_->get_joint_actual_position();
 
-    virtual void close() = 0;
-};
+        auto buffer = new double[5 * 4];
+        for (size_t i = 0; i < 5; i++)
+            for (size_t j = 0; j < 4; j++)
+                buffer[4 * i + j] = positions[i][j].load(std::memory_order::relaxed);
+        py::capsule free(buffer, [](void* ptr) { delete[] static_cast<double*>(ptr); });
 
-namespace internal {
-template <bool enable_upstream, typename T>
-inline std::unique_ptr<IController>
-    create_controller_helper_impl(wujihandcpp::device::Hand& hand, const T& filter) {
-    class Controller : public IController {
-        using ControllerT = decltype(hand.realtime_controller<enable_upstream>(std::declval<T>()));
-
-    public:
-        explicit Controller(ControllerT&& controller) noexcept
-            : controller_(std::move(controller)) {}
-
-        py::array_t<double> get_joint_actual_position() override {
-            if (!controller_)
-                throw std::runtime_error("Controller is closed.");
-
-            if constexpr (!enable_upstream)
-                throw std::logic_error("Upstream is disabled.");
-            else {
-                const auto& positions = controller_->get_joint_actual_position();
-
-                auto buffer = new double[5 * 4];
-                for (size_t i = 0; i < 5; i++)
-                    for (size_t j = 0; j < 4; j++)
-                        buffer[4 * i + j] = positions[i][j].load(std::memory_order::relaxed);
-                py::capsule free(buffer, [](void* ptr) { delete[] static_cast<double*>(ptr); });
-
-                return py::array_t<double>({5, 4}, buffer, free);
-            }
-        }
-
-        void set_joint_target_position(const py::array_t<double>& array) override {
-            if (!controller_)
-                throw std::runtime_error("Controller is closed.");
-
-            if (array.ndim() != 2 || array.shape()[0] != 5 || array.shape()[1] != 4)
-                throw std::runtime_error("Array shape must be {5, 4}!");
-
-            auto r = array.unchecked<2>();
-            double target_positions[5][4];
-            for (size_t i = 0; i < 5; ++i)
-                for (size_t j = 0; j < 4; ++j)
-                    target_positions[i][j] = r(i, j);
-
-            controller_->set_joint_target_position(target_positions);
-        }
-
-        void close() override { controller_ = std::nullopt; }
-
-    private:
-        std::optional<ControllerT> controller_;
-    };
-
-    return std::make_unique<Controller>(hand.realtime_controller<enable_upstream>(filter));
-}
-} // namespace internal
-
-template <typename T>
-inline std::unique_ptr<IController> create_controller_helper(
-    wujihandcpp::device::Hand& hand, bool enable_upstream, const T& filter) {
-    if (enable_upstream)
-        return internal::create_controller_helper_impl<true>(hand, filter);
-    else {
-        return internal::create_controller_helper_impl<false>(hand, filter);
+        return py::array_t<double>({5, 4}, buffer, free);
     }
-}
+
+    void set_joint_target_position(const py::array_t<double>& array) {
+        if (!controller_)
+            throw std::runtime_error("Controller is closed.");
+
+        if (array.ndim() != 2 || array.shape()[0] != 5 || array.shape()[1] != 4)
+            throw std::runtime_error("Array shape must be {5, 4}!");
+
+        auto r = array.unchecked<2>();
+        double target_positions[5][4];
+        for (size_t i = 0; i < 5; ++i)
+            for (size_t j = 0; j < 4; ++j)
+                target_positions[i][j] = r(i, j);
+
+        controller_->set_joint_target_position(target_positions);
+    }
+
+    void close() { controller_.reset(); }
+
+private:
+    std::unique_ptr<wujihandcpp::device::IController> controller_;
+};

--- a/src/filter.hpp
+++ b/src/filter.hpp
@@ -14,7 +14,7 @@ class IFilter {
 public:
     virtual ~IFilter() = default;
 
-    virtual std::unique_ptr<IController>
+    virtual IControllerWrapper
         create_controller(wujihandcpp::device::Hand& hand, bool enable_upstream) const = 0;
 };
 
@@ -23,10 +23,14 @@ public:
     explicit LowPass(double cutoff_freq) noexcept
         : cutoff_freq_(cutoff_freq) {}
 
-    std::unique_ptr<IController>
+    IControllerWrapper
         create_controller(wujihandcpp::device::Hand& hand, bool enable_upstream) const override {
-        return create_controller_helper(
-            hand, enable_upstream, wujihandcpp::filter::LowPass{cutoff_freq_});
+        if (enable_upstream)
+            return IControllerWrapper(
+                hand.realtime_controller<true>(wujihandcpp::filter::LowPass{cutoff_freq_}));
+        else
+            return IControllerWrapper(
+                hand.realtime_controller<false>(wujihandcpp::filter::LowPass{cutoff_freq_}));
     }
 
     const double cutoff_freq_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,15 +36,15 @@ PYBIND11_MODULE(_core, m) {
         }
     });
 
-    py::class_<IController>(m, "IController")
-        .def("__enter__", [](IController& self) -> IController& { return self; })
+    py::class_<IControllerWrapper>(m, "IController")
+        .def("__enter__", [](IControllerWrapper& self) -> IControllerWrapper& { return self; })
         .def(
-            "__exit__", [](IController& self, const py::object&, const py::object&,
+            "__exit__", [](IControllerWrapper& self, const py::object&, const py::object&,
                            const py::object&) { self.close(); })
-        .def("close", &IController::close)
-        .def("get_joint_actual_position", &IController::get_joint_actual_position)
+        .def("close", &IControllerWrapper::close)
+        .def("get_joint_actual_position", &IControllerWrapper::get_joint_actual_position)
         .def(
-            "set_joint_target_position", &IController::set_joint_target_position,
+            "set_joint_target_position", &IControllerWrapper::set_joint_target_position,
             py::arg("value_array"));
 
     filter::init_module(m);

--- a/src/wrapper.hpp
+++ b/src/wrapper.hpp
@@ -253,8 +253,7 @@ public:
         return py::array_t<ValueType>({5, 4}, buffer, free);
     }
 
-    std::unique_ptr<IController>
-        realtime_controller(bool enable_upstream, const filter::IFilter& filter) {
+    IControllerWrapper realtime_controller(bool enable_upstream, const filter::IFilter& filter) {
         return filter.create_controller(*this, enable_upstream);
     }
 
@@ -262,20 +261,21 @@ public:
     void stop_latency_test() { T::stop_latency_test(); }
 
     // Raw SDO operations - only available for Hand
-    py::bytes raw_sdo_read(int finger_id, int joint_id, uint16_t index, uint8_t sub_index, double timeout)
-        requires std::is_same_v<T, wujihandcpp::device::Hand>
-    {
+    py::bytes
+        raw_sdo_read(int finger_id, int joint_id, uint16_t index, uint8_t sub_index, double timeout)
+            requires std::is_same_v<T, wujihandcpp::device::Hand> {
         std::vector<std::byte> result;
         {
             py::gil_scoped_release release;
-            result = T::raw_sdo_read(finger_id, joint_id, index, sub_index, seconds_to_duration(timeout));
+            result = T::raw_sdo_read(
+                finger_id, joint_id, index, sub_index, seconds_to_duration(timeout));
         }
         return py::bytes(reinterpret_cast<const char*>(result.data()), result.size());
     }
 
-    void raw_sdo_write(int finger_id, int joint_id, uint16_t index, uint8_t sub_index, py::bytes data, double timeout)
-        requires std::is_same_v<T, wujihandcpp::device::Hand>
-    {
+    void raw_sdo_write(
+        int finger_id, int joint_id, uint16_t index, uint8_t sub_index, py::bytes data,
+        double timeout) requires std::is_same_v<T, wujihandcpp::device::Hand> {
         // Convert py::bytes to std::string while GIL is held
         std::string buffer = static_cast<std::string>(data);
 

--- a/wujihandcpp/include/wujihandcpp/data/hand.hpp
+++ b/wujihandcpp/include/wujihandcpp/data/hand.hpp
@@ -14,7 +14,14 @@ class Joint;
 
 namespace data {
 namespace hand {
+
 struct Handedness : ReadOnlyData<device::Hand, 0x5090, 0, uint8_t> {};
+
+struct HostTimeoutCounter : WriteOnlyData<device::Hand, 0x50A0, 1, uint32_t> {
+    static constexpr StorageInfo info(uint32_t) {
+        return StorageInfo{sizeof(uint32_t), index, sub_index, StorageInfo::HOST_HEARTBEAT};
+    }
+};
 
 struct FirmwareVersion : ReadOnlyData<device::Hand, 0x5201, 1, uint32_t> {};
 struct FirmwareDate : ReadOnlyData<device::Hand, 0x5201, 2, uint32_t> {};
@@ -25,13 +32,17 @@ struct SystemTime : ReadOnlyData<device::Hand, 0x520A, 1, uint32_t> {};
 struct Temperature : ReadOnlyData<device::Hand, 0x520A, 9, float> {};
 struct InputVoltage : ReadOnlyData<device::Hand, 0x520A, 10, float> {};
 
+struct RPdoDirectlyDistribute : WriteOnlyData<device::Hand, 0x52A0, 3, uint8_t> {};
+struct TPdoProactivelyReport : WriteOnlyData<device::Hand, 0x52A0, 4, uint8_t> {};
 struct PdoEnabled : WriteOnlyData<device::Hand, 0x52A0, 5, uint8_t> {};
+
 struct RPdoId : WriteOnlyData<device::Hand, 0x52A4, 1, uint16_t> {};
 struct TPdoId : WriteOnlyData<device::Hand, 0x52A4, 2, uint16_t> {};
 
 struct PdoInterval : WriteOnlyData<device::Hand, 0x52A4, 5, uint32_t> {};
 struct RPdoTriggerOffset : WriteOnlyData<device::Hand, 0x52A4, 6, uint32_t> {};
 struct TPdoTriggerOffset : WriteOnlyData<device::Hand, 0x52A4, 7, uint32_t> {};
+
 } // namespace hand
 } // namespace data
 

--- a/wujihandcpp/include/wujihandcpp/data/joint.hpp
+++ b/wujihandcpp/include/wujihandcpp/data/joint.hpp
@@ -3,7 +3,6 @@
 #include <cstdint>
 
 #include "wujihandcpp/data/helper.hpp"
-#include "wujihandcpp/protocol/handler.hpp"
 
 namespace wujihandcpp {
 
@@ -22,6 +21,8 @@ struct FirmwareDate : ReadOnlyData<device::Joint, 0x01, 2, uint32_t> {};
 struct ControlMode : WriteOnlyData<device::Joint, 0x02, 1, uint16_t> {};
 
 struct SinLevel : WriteOnlyData<device::Joint, 0x05, 8, uint16_t> {};
+struct PositionFilterCutoffFreq : WriteOnlyData<device::Joint, 0x05, 19, float> {};
+struct TorqueSlopeLimitPerCycle : WriteOnlyData<device::Joint, 0x05, 20, float> {};
 
 struct CurrentLimit : WriteOnlyData<device::Joint, 0x07, 2, uint16_t> {};
 

--- a/wujihandcpp/include/wujihandcpp/device/controller.hpp
+++ b/wujihandcpp/include/wujihandcpp/device/controller.hpp
@@ -1,9 +1,21 @@
 #pragma once
 
 #include <atomic>
+#include <stdexcept>
 
 namespace wujihandcpp {
 namespace device {
+
+class IController {
+public:
+    virtual ~IController() = default;
+
+    virtual auto get_joint_actual_position() -> const std::atomic<double> (&)[5][4] {
+        throw std::logic_error("Upstream is disabled.");
+    };
+
+    virtual void set_joint_target_position(const double (&positions)[5][4]) = 0;
+};
 
 class IRealtimeController {
 public:

--- a/wujihandcpp/include/wujihandcpp/device/hand.hpp
+++ b/wujihandcpp/include/wujihandcpp/device/hand.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 
+#include <atomic>
 #include <memory>
 #include <span>
 #include <stdexcept>
@@ -9,11 +10,13 @@
 #include <vector>
 
 #include "wujihandcpp/data/hand.hpp"
+#include "wujihandcpp/data/helper.hpp"
 #include "wujihandcpp/data/joint.hpp"
 #include "wujihandcpp/device/controller.hpp"
 #include "wujihandcpp/device/data_operator.hpp"
 #include "wujihandcpp/device/data_tuple.hpp"
 #include "wujihandcpp/device/finger.hpp"
+#include "wujihandcpp/filter/low_pass.hpp"
 #include "wujihandcpp/protocol/handler.hpp"
 #include "wujihandcpp/utility/logging.hpp"
 
@@ -23,85 +26,6 @@ namespace device {
 class Hand : public DataOperator<Hand> {
     friend class DataOperator;
 
-    template <typename FilterT, bool upstream_enabled>
-    class ControllerOperator;
-
-    template <typename FilterT>
-    class ControllerOperator<FilterT, false> final {
-    public:
-        explicit ControllerOperator(Hand& hand, FilteredController<FilterT, false>& controller)
-            : hand_(hand)
-            , controller_(&controller) {}
-
-        ControllerOperator(const ControllerOperator&) = delete;
-        ControllerOperator& operator=(const ControllerOperator&) = delete;
-
-        ControllerOperator(ControllerOperator&& other) noexcept
-            : hand_(other.hand_)
-            , controller_(other.controller_) {
-            other.controller_ = nullptr;
-        }
-        ControllerOperator& operator=(ControllerOperator&&) = delete;
-
-        ~ControllerOperator() {
-            if (!controller_)
-                return;
-            try {
-                hand_.detach_realtime_controller();
-            } catch (...) {
-                // TODO: Add log here
-            }
-        }
-
-        void set_joint_target_position(const double (&positions)[5][4]) {
-            controller_->set(positions);
-        }
-
-    private:
-        Hand& hand_;
-        FilteredController<FilterT, false>* controller_;
-    };
-
-    template <typename FilterT>
-    class ControllerOperator<FilterT, true> final {
-    public:
-        explicit ControllerOperator(Hand& hand, FilteredController<FilterT, true>& controller)
-            : hand_(hand)
-            , controller_(&controller) {}
-
-        ControllerOperator(const ControllerOperator&) = delete;
-        ControllerOperator& operator=(const ControllerOperator&) = delete;
-
-        ControllerOperator(ControllerOperator&& other) noexcept
-            : hand_(other.hand_)
-            , controller_(other.controller_) {
-            other.controller_ = nullptr;
-        }
-        ControllerOperator& operator=(ControllerOperator&&) = delete;
-
-        ~ControllerOperator() {
-            if (!controller_)
-                return;
-            try {
-                hand_.detach_realtime_controller();
-            } catch (...) {
-                // TODO: Add log here
-            }
-        }
-
-        auto get_joint_actual_position() -> const std::atomic<double> (&)[5][4] {
-            return controller_->get();
-        }
-
-        void set_joint_target_position(const double (&positions)[5][4]) {
-            controller_->set(positions);
-        }
-
-    private:
-        Hand& hand_;
-        FilteredController<FilterT, true>* controller_;
-    };
-
 public:
     explicit Hand(
         const char* serial_number = nullptr, int32_t usb_pid = -1, uint16_t usb_vid = 0x0483,
@@ -109,15 +33,35 @@ public:
         : handler_(usb_vid, usb_pid, serial_number, data_count()) {
 
         init_storage_info(mask);
+        handler_.start_transmit_receive();
 
         try {
             check_firmware_version();
 
+            if (feature_tpdo_proactively_report_)
+                handler_.enable_host_heartbeat();
+
             write<data::joint::Enabled>(false);
+
             Latch latch;
-            write_async<data::joint::ControlMode>(latch, 6);
-            write_async<data::joint::CurrentLimit>(latch, 1000);
+            write_async<data::joint::ControlMode>(latch, feature_firmware_filter_ ? 9 : 6);
+
+            if (feature_firmware_filter_) {
+                write_async<data::hand::RPdoId>(latch, 0x01);
+                write_async<data::hand::TPdoId>(latch, 0x01);
+                write_async<data::hand::PdoInterval>(
+                    latch, feature_rpdo_directly_distribute_ ? 1000 : 2000);
+                write_async<data::hand::PdoEnabled>(latch, 1);
+            } else
+                write_async<data::joint::CurrentLimit>(latch, 1000);
+
+            if (feature_rpdo_directly_distribute_)
+                write_async<data::hand::RPdoDirectlyDistribute>(latch, 1);
+            if (feature_tpdo_proactively_report_)
+                write_async<data::hand::TPdoProactivelyReport>(latch, 1);
+
             latch.wait();
+
         } catch (const TimeoutError&) {
             throw TimeoutError("Hand initialization timed out: joint configuration incomplete");
         }
@@ -135,25 +79,34 @@ public:
                 "The firmware version (" + hand_version.to_string()
                 + ") is outdated. Please contact after-sales service for an upgrade.");
 
-        if (hand_version >= data::FirmwareVersionData{3, 1, 0, 'D'}) {
+        auto joint_version =
+            data::FirmwareVersionData{finger(0).joint(0).get<data::joint::FirmwareVersion>()};
+        bool joint_version_consistent = true;
+        for (int i = 0; i < 5; i++)
+            for (int j = 0; j < 4; j++)
+                if (joint_version
+                    != data::FirmwareVersionData{
+                        finger(i).joint(j).get<data::joint::FirmwareVersion>()})
+                    joint_version_consistent = false;
+
+        bool log_full_system_version = (hand_version >= data::FirmwareVersionData{3, 1, 0, 'D'});
+        if (log_full_system_version) {
             auto full_system_version =
                 data::FirmwareVersionData{read<data::hand::FullSystemFirmwareVersion>()};
-            std::string firmware_msg = "Using firmware version: " + full_system_version.to_string();
-            logging::log(logging::Level::INFO, firmware_msg.c_str(), firmware_msg.size());
-        } else {
+            if (full_system_version.major > 0) {
+                std::string firmware_msg =
+                    "Using firmware version: " + full_system_version.to_string();
+                logging::log(logging::Level::INFO, firmware_msg.c_str(), firmware_msg.size());
+            } else
+                log_full_system_version = false;
+        }
+
+        if (!log_full_system_version) {
             std::string firmware_msg =
                 "Using firmware version: " + hand_version.to_string() + " & ";
 
-            uint32_t joint_version = finger(0).joint(0).get<data::joint::FirmwareVersion>();
-            bool joint_version_consistent = true;
-            for (int i = 0; i < 5; i++)
-                for (int j = 0; j < 4; j++)
-                    joint_version_consistent =
-                        joint_version_consistent
-                        && joint_version == finger(i).joint(j).get<data::joint::FirmwareVersion>();
-
             if (joint_version_consistent) {
-                firmware_msg += data::FirmwareVersionData{joint_version}.to_string();
+                firmware_msg += joint_version.to_string();
                 logging::log(logging::Level::INFO, firmware_msg.c_str(), firmware_msg.size());
             } else {
                 firmware_msg += "[Matrix]";
@@ -174,9 +127,26 @@ public:
                         joint_firmware_msg.size());
                 }
 
-                const char warning_msg[] = "Inconsistent driver board firmware version detected";
+                constexpr char warning_msg[] =
+                    "Inconsistent driver board firmware version detected";
                 logging::log(logging::Level::WARN, warning_msg, sizeof(warning_msg) - 1);
             }
+        }
+
+        if (joint_version_consistent && joint_version >= data::FirmwareVersionData{6, 4, 0, 'J'}) {
+            feature_firmware_filter_ = true;
+            constexpr char debug_msg[] = "Firmware filter enabled";
+            logging::log(logging::Level::DEBUG, debug_msg, sizeof(debug_msg) - 1);
+        }
+        if (hand_version >= data::FirmwareVersionData{3, 2, 0, 'B'}) {
+            feature_rpdo_directly_distribute_ = true;
+            constexpr char debug_msg[] = "RPdo directly distribute enabled";
+            logging::log(logging::Level::DEBUG, debug_msg, sizeof(debug_msg) - 1);
+        }
+        if (false) { // TPdo proactively report is still not ready to perform test
+            feature_tpdo_proactively_report_ = true;
+            constexpr char debug_msg[] = "TPdo proactively report enabled";
+            logging::log(logging::Level::DEBUG, debug_msg, sizeof(debug_msg) - 1);
         }
     }
 
@@ -192,74 +162,41 @@ public:
         return sub(index);
     }
 
-    template <bool enable_upstream, typename FilterT>
-    SDK_CPP20_REQUIRES(requires(const FilterT& f, typename FilterT::Unit& u, double v) {
-        { u.reset(f, v) };
-        { u.input(f, v) };
-        { u.step(f) } -> std::convertible_to<double>;
-    })
-    auto realtime_controller(const FilterT& filter)
-        -> ControllerOperator<FilterT, enable_upstream> {
-        bool last_enabled[5][4];
-        save_and_enable_joints(last_enabled);
-        read<data::joint::ActualPosition>();
-        revert_enabled_joints(last_enabled);
-
-        double positions[5][4];
-        for (int i = 0; i < 5; i++)
-            for (int j = 0; j < 4; j++)
-                positions[i][j] = finger(i).joint(j).get<data::joint::ActualPosition>();
-
-        auto controller =
-            std::make_unique<FilteredController<FilterT, enable_upstream>>(positions, filter);
-        auto controller_operator = ControllerOperator<FilterT, enable_upstream>(*this, *controller);
-        attach_realtime_controller(std::move(controller), enable_upstream);
-
-        return controller_operator;
+    auto realtime_get_joint_actual_position() -> const std::atomic<double> (&)[5][4] {
+        return handler_.realtime_get_joint_actual_position();
     }
 
-    void attach_realtime_controller(
-        std::unique_ptr<IRealtimeController> controller, bool enable_upstream) {
-        if (!controller)
-            throw std::invalid_argument("Controller pointer must not be null.");
-
-        bool last_enabled[5][4];
-        save_and_disable_joints(last_enabled);
-
-        {
-            Latch latch;
-            write_async<data::joint::ControlMode>(latch, 5);
-            write_async<data::hand::RPdoId>(latch, 0x01);
-            if (enable_upstream)
-                write_async<data::hand::TPdoId>(latch, 0x01);
-            else
-                write_async<data::hand::TPdoId>(latch, 0x00);
-            write_async<data::hand::PdoInterval>(latch, 2000);
-            write_async<data::hand::PdoEnabled>(latch, 1);
-            latch.wait();
-        }
-
-        revert_disabled_joints(last_enabled);
-
-        handler_.attach_realtime_controller(controller.get(), enable_upstream);
-        auto ignore = controller.release();
-        (void)ignore;
+    void realtime_set_joint_target_position(const double (&positions)[5][4]) {
+        handler_.realtime_set_joint_target_position(positions);
     }
 
-    std::unique_ptr<IRealtimeController> detach_realtime_controller() {
-        bool last_enabled[5][4];
-        save_and_disable_joints(last_enabled);
+    template <bool enable_upstream>
+    auto realtime_controller(const filter::LowPass& filter) -> std::unique_ptr<IController> {
+        if (feature_firmware_filter_) {
+            write<data::joint::PositionFilterCutoffFreq>(static_cast<float>(filter.cutoff_freq()));
 
-        {
-            Latch latch;
-            write_async<data::joint::ControlMode>(latch, 6);
-            write_async<data::hand::PdoEnabled>(latch, 0);
-            latch.wait();
+            return std::make_unique<CompatibleControllerOperator>(*this);
+        } else {
+            bool last_enabled[5][4];
+            save_and_enable_joints(last_enabled);
+            read<data::joint::ActualPosition>();
+            revert_enabled_joints(last_enabled);
+
+            double positions[5][4];
+            for (int i = 0; i < 5; i++)
+                for (int j = 0; j < 4; j++)
+                    positions[i][j] = finger(i).joint(j).get<data::joint::ActualPosition>();
+
+            auto controller =
+                std::make_unique<FilteredController<filter::LowPass, enable_upstream>>(
+                    positions, filter);
+            auto controller_operator =
+                std::make_unique<FilteredControllerOperator<filter::LowPass, enable_upstream>>(
+                    *this, *controller);
+            attach_realtime_controller(std::move(controller), enable_upstream);
+
+            return controller_operator;
         }
-
-        revert_disabled_joints(last_enabled);
-
-        return std::unique_ptr<IRealtimeController>{handler_.detach_realtime_controller()};
     }
 
     void start_latency_test() {
@@ -314,6 +251,150 @@ public:
     }
 
 private:
+    class CompatibleControllerOperator : public IController {
+    public:
+        explicit CompatibleControllerOperator(Hand& hand)
+            : hand_(hand) {}
+
+        ~CompatibleControllerOperator() override = default;
+
+        auto get_joint_actual_position() -> const std::atomic<double> (&)[5][4] override {
+            return hand_.realtime_get_joint_actual_position();
+        }
+
+        void set_joint_target_position(const double (&positions)[5][4]) override {
+            hand_.realtime_set_joint_target_position(positions);
+        }
+
+    private:
+        Hand& hand_;
+    };
+
+    template <typename FilterT, bool upstream_enabled>
+    class FilteredControllerOperator;
+
+    template <typename FilterT>
+    class FilteredControllerOperator<FilterT, false> : public IController {
+    public:
+        explicit FilteredControllerOperator(
+            Hand& hand, FilteredController<FilterT, false>& controller)
+            : hand_(hand)
+            , controller_(&controller) {}
+
+        FilteredControllerOperator(const FilteredControllerOperator&) = delete;
+        FilteredControllerOperator& operator=(const FilteredControllerOperator&) = delete;
+
+        FilteredControllerOperator(FilteredControllerOperator&& other) noexcept
+            : hand_(other.hand_)
+            , controller_(other.controller_) {
+            other.controller_ = nullptr;
+        }
+        FilteredControllerOperator& operator=(FilteredControllerOperator&&) = delete;
+
+        ~FilteredControllerOperator() override {
+            if (!controller_)
+                return;
+            try {
+                hand_.detach_realtime_controller();
+            } catch (...) {
+                // TODO: Add log here
+            }
+        }
+
+        void set_joint_target_position(const double (&positions)[5][4]) override {
+            controller_->set(positions);
+        }
+
+    private:
+        Hand& hand_;
+        FilteredController<FilterT, false>* controller_;
+    };
+
+    template <typename FilterT>
+    class FilteredControllerOperator<FilterT, true> : public IController {
+    public:
+        explicit FilteredControllerOperator(
+            Hand& hand, FilteredController<FilterT, true>& controller)
+            : hand_(hand)
+            , controller_(&controller) {}
+
+        FilteredControllerOperator(const FilteredControllerOperator&) = delete;
+        FilteredControllerOperator& operator=(const FilteredControllerOperator&) = delete;
+
+        FilteredControllerOperator(FilteredControllerOperator&& other) noexcept
+            : hand_(other.hand_)
+            , controller_(other.controller_) {
+            other.controller_ = nullptr;
+        }
+        FilteredControllerOperator& operator=(FilteredControllerOperator&&) = delete;
+
+        ~FilteredControllerOperator() override {
+            if (!controller_)
+                return;
+            try {
+                hand_.detach_realtime_controller();
+            } catch (...) {
+                // TODO: Add log here
+            }
+        }
+
+        auto get_joint_actual_position() -> const std::atomic<double> (&)[5][4] override {
+            return controller_->get();
+        }
+
+        void set_joint_target_position(const double (&positions)[5][4]) override {
+            controller_->set(positions);
+        }
+
+    private:
+        Hand& hand_;
+        FilteredController<FilterT, true>* controller_;
+    };
+
+    void attach_realtime_controller(
+        std::unique_ptr<IRealtimeController> controller, bool enable_upstream) {
+        if (!controller)
+            throw std::invalid_argument("Controller pointer must not be null.");
+
+        bool last_enabled[5][4];
+        save_and_disable_joints(last_enabled);
+
+        {
+            Latch latch;
+            write_async<data::joint::ControlMode>(latch, 5);
+            write_async<data::hand::RPdoId>(latch, 0x01);
+            if (enable_upstream)
+                write_async<data::hand::TPdoId>(latch, 0x01);
+            else
+                write_async<data::hand::TPdoId>(latch, 0x00);
+            write_async<data::hand::PdoInterval>(latch, 2000);
+            write_async<data::hand::PdoEnabled>(latch, 1);
+            latch.wait();
+        }
+
+        revert_disabled_joints(last_enabled);
+
+        handler_.attach_realtime_controller(controller.get(), enable_upstream);
+        auto ignore = controller.release();
+        (void)ignore;
+    }
+
+    std::unique_ptr<IRealtimeController> detach_realtime_controller() {
+        bool last_enabled[5][4];
+        save_and_disable_joints(last_enabled);
+
+        {
+            Latch latch;
+            write_async<data::joint::ControlMode>(latch, 6);
+            write_async<data::hand::PdoEnabled>(latch, 0);
+            latch.wait();
+        }
+
+        revert_disabled_joints(last_enabled);
+
+        return std::unique_ptr<IRealtimeController>{handler_.detach_realtime_controller()};
+    }
+
     static uint16_t calculate_index_offset(int finger_id, int joint_id) {
         if (finger_id == -1)
             return 0x0000; // Hand level
@@ -367,12 +448,18 @@ private:
     }
 
     using Datas = DataTuple<
-        data::hand::Handedness, data::hand::FirmwareVersion, data::hand::FirmwareDate,
-        data::hand::FullSystemFirmwareVersion, data::hand::SystemTime, data::hand::Temperature,
-        data::hand::InputVoltage, data::hand::PdoEnabled, data::hand::RPdoId, data::hand::TPdoId,
-        data::hand::PdoInterval, data::hand::RPdoTriggerOffset, data::hand::TPdoTriggerOffset>;
+        data::hand::Handedness, data::hand::HostTimeoutCounter, data::hand::FirmwareVersion,
+        data::hand::FirmwareDate, data::hand::FullSystemFirmwareVersion, data::hand::SystemTime,
+        data::hand::Temperature, data::hand::InputVoltage, data::hand::RPdoDirectlyDistribute,
+        data::hand::TPdoProactivelyReport, data::hand::PdoEnabled, data::hand::RPdoId,
+        data::hand::TPdoId, data::hand::PdoInterval, data::hand::RPdoTriggerOffset,
+        data::hand::TPdoTriggerOffset>;
 
     protocol::Handler handler_;
+
+    bool feature_firmware_filter_ = false;
+    bool feature_rpdo_directly_distribute_ = false;
+    bool feature_tpdo_proactively_report_ = false;
 
     static constexpr uint16_t index_offset_ = 0x0000;
     static constexpr int storage_offset_ = 0;

--- a/wujihandcpp/include/wujihandcpp/device/joint.hpp
+++ b/wujihandcpp/include/wujihandcpp/device/joint.hpp
@@ -22,7 +22,8 @@ private:
 
     using Datas = DataTuple<
         data::joint::FirmwareVersion, data::joint::FirmwareDate, data::joint::ControlMode,
-        data::joint::SinLevel, data::joint::CurrentLimit, data::joint::BusVoltage,
+        data::joint::SinLevel, data::joint::PositionFilterCutoffFreq,
+        data::joint::TorqueSlopeLimitPerCycle, data::joint::CurrentLimit, data::joint::BusVoltage,
         data::joint::Temperature, data::joint::ResetError, data::joint::ErrorCode,
         data::joint::Enabled, data::joint::ActualPosition, data::joint::TargetPosition,
         data::joint::UpperLimit, data::joint::LowerLimit>;

--- a/wujihandcpp/include/wujihandcpp/filter/low_pass.hpp
+++ b/wujihandcpp/include/wujihandcpp/filter/low_pass.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <iostream>
 
 namespace wujihandcpp {
 namespace filter {
@@ -34,6 +33,8 @@ public:
 
     explicit LowPass(double cutoff_freq) noexcept
         : cutoff_freq_(cutoff_freq) {};
+
+    double cutoff_freq() const noexcept { return cutoff_freq_; }
 
     static constexpr double calculate_alpha(double cutoff_freq, double sampling_freq) {
         constexpr double pi = 3.141592653589793;

--- a/wujihandcpp/include/wujihandcpp/protocol/handler.hpp
+++ b/wujihandcpp/include/wujihandcpp/protocol/handler.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include <atomic>
 #include <chrono>
 #include <span>
 #include <type_traits>
@@ -42,6 +43,7 @@ public:
             POSITION_REVERSED = 1ul << 3,
             VELOCITY = 1ul << 4,
             VELOCITY_REVERSED = 1ul << 5,
+            HOST_HEARTBEAT = 1ul << 6
         };
         uint32_t policy : 30;
     };
@@ -78,6 +80,8 @@ public:
 
     WUJIHANDCPP_API void init_storage_info(int storage_id, StorageInfo info);
 
+    WUJIHANDCPP_API void start_transmit_receive();
+
     WUJIHANDCPP_API void
         read_async_unchecked(int storage_id, std::chrono::steady_clock::duration::rep timeout);
 
@@ -91,6 +95,13 @@ public:
     WUJIHANDCPP_API void write_async(
         Buffer8 data, int storage_id, std::chrono::steady_clock::duration::rep timeout,
         void (*callback)(Buffer8 context, bool success), Buffer8 callback_context);
+
+    WUJIHANDCPP_API void enable_host_heartbeat();
+
+    WUJIHANDCPP_API auto realtime_get_joint_actual_position()
+        -> const std::atomic<double> (&)[5][4];
+
+    WUJIHANDCPP_API void realtime_set_joint_target_position(const double (&positions)[5][4]);
 
     WUJIHANDCPP_API void
         attach_realtime_controller(device::IRealtimeController* controller, bool enable_upstream);

--- a/wujihandcpp/src/protocol/handler.cpp
+++ b/wujihandcpp/src/protocol/handler.cpp
@@ -43,13 +43,7 @@ public:
         , storage_(std::make_unique<StorageUnit[]>(storage_unit_count))
         , transport_(std::move(transport))
         , sdo_builder_(*transport_, 0x21)
-        , pdo_builder_(*transport_, 0x11)
-        , sdo_thread_([this](const std::stop_token& stop_token) { sdo_thread_main(stop_token); }) {
-
-        transport_->receive([this](const std::byte* buffer, size_t size) {
-            receive_transfer_completed_callback(buffer, size);
-        });
-    }
+        , pdo_builder_(*transport_, 0x11) {}
 
     ~Impl() = default;
 
@@ -57,6 +51,15 @@ public:
         storage_[storage_id].info = info;
         IndexMapKey index{.index = info.index, .sub_index = info.sub_index};
         index_storage_map_[std::bit_cast<uint32_t>(index)] = &storage_[storage_id];
+    }
+
+    void start_transmit_receive() {
+        transport_->receive([this](const std::byte* buffer, size_t size) {
+            receive_transfer_completed_callback(buffer, size);
+        });
+
+        sdo_thread_ = std::jthread{
+            [this](const std::stop_token& stop_token) { sdo_thread_main(stop_token); }};
     }
 
     void read_async_unchecked(int storage_id, std::chrono::steady_clock::duration::rep timeout) {
@@ -123,6 +126,23 @@ public:
         storage_[storage_id].operation.store(
             Operation{.mode = Operation::Mode::WRITE, .state = Operation::State::WAITING},
             std::memory_order::release);
+    }
+
+    void enable_host_heartbeat() {
+        host_heartbeat_enabled_.store(true, std::memory_order::relaxed);
+    }
+
+    auto realtime_get_joint_actual_position() -> const std::atomic<double> (&)[5][4] {
+        return pdo_read_result_;
+    }
+
+    void realtime_set_joint_target_position(const double (&positions)[5][4]) {
+        operation_thread_check();
+
+        if (realtime_controller_) [[unlikely]]
+            std::terminate(); // Logically impossible, only for protection
+
+        pdo_write_async_unchecked(true, positions, 0);
     }
 
     void attach_realtime_controller(device::IRealtimeController* controller, bool enable_upstream) {
@@ -595,13 +615,28 @@ private:
             std::chrono::duration_cast<std::chrono::steady_clock::duration>(
                 std::chrono::duration<double>(1.0 / update_rate));
 
+        unsigned int update_index = 0;
         while (!stop_token.stop_requested()) {
             auto now = std::chrono::steady_clock::now();
 
             for (size_t i = 0; i < storage_unit_count_; i++) {
                 auto& storage = storage_[i];
-
                 auto operation = storage.operation.load(std::memory_order::acquire);
+
+                // Reset the host counter every 320ms
+                if (host_heartbeat_enabled_.load(std::memory_order::relaxed)
+                    && storage.info.policy & Handler::StorageInfo::HOST_HEARTBEAT
+                    && update_index % 64 == 0
+                    && storage.operation.load(std::memory_order::relaxed).mode
+                           == Operation::Mode::NONE) {
+                    store_data(storage, Buffer8{uint32_t(0)});
+                    storage.timeout = std::chrono::milliseconds(500);
+                    storage.callback = nullptr;
+                    operation = Operation{
+                        .mode = Operation::Mode::WRITE, .state = Operation::State::WAITING};
+                    storage.operation.store(operation, std::memory_order::relaxed);
+                }
+
                 if (operation.mode == Operation::Mode::NONE)
                     continue;
 
@@ -714,6 +749,7 @@ private:
             sdo_builder_.finalize();
 
             std::this_thread::sleep_for(update_period);
+            update_index++;
         }
     }
 
@@ -724,8 +760,12 @@ private:
             const auto& data = read_frame_struct<protocol::pdo::CommandResult>(pointer, sentinel);
 
             for (int i = 0; i < 5; i++)
-                for (int j = 0; j < 4; j++)
-                    pdo_read_result_[i][j].store(data.positions[i][j], std::memory_order::relaxed);
+                for (int j = 0; j < 4; j++) {
+                    double value = extract_raw_position(data.positions[i][j]);
+                    if (j == 0 && i != 0)
+                        value = -value;
+                    pdo_read_result_[i][j].store(value, std::memory_order::relaxed);
+                }
 
             pdo_read_result_version_.store(
                 pdo_read_result_version_.load(std::memory_order::relaxed) + 1,
@@ -757,13 +797,9 @@ private:
             utility::TickExecutor{[&](const utility::TickContext& context) {
                 device::IRealtimeController::JointPositions positions;
                 for (int i = 0; i < 5; i++)
-                    for (int j = 0; j < 4; j++) {
-                        auto& value = positions.value[i][j];
-                        value = extract_raw_position(
-                            pdo_read_result_[i][j].load(std::memory_order::relaxed));
-                        if (j == 0 && i != 0)
-                            value = -value;
-                    }
+                    for (int j = 0; j < 4; j++)
+                        positions.value[i][j] =
+                            pdo_read_result_[i][j].load(std::memory_order::relaxed);
 
                 auto target_positions = realtime_controller_->step(&positions);
 
@@ -865,8 +901,10 @@ private:
     };
     std::map<uint32_t, StorageUnit*> index_storage_map_;
 
-    std::atomic<int32_t> pdo_read_result_[5][4];
+    std::atomic<double> pdo_read_result_[5][4];
     std::atomic<uint64_t> pdo_read_result_version_ = 0;
+    static_assert(std::atomic<double>::is_always_lock_free);
+    static_assert(std::atomic<uint64_t>::is_always_lock_free);
 
     std::unique_ptr<transport::ITransport> transport_;
     FrameBuilder sdo_builder_;
@@ -875,6 +913,7 @@ private:
     std::unique_ptr<LatencyTester> latency_tester_;
     std::mutex latency_tester_mutex_;
 
+    std::atomic<bool> host_heartbeat_enabled_ = false;
     std::jthread sdo_thread_;
 
     std::unique_ptr<device::IRealtimeController> realtime_controller_;
@@ -895,6 +934,8 @@ WUJIHANDCPP_API void Handler::init_storage_info(int storage_id, StorageInfo info
     impl_->init_storage_info(storage_id, info);
 }
 
+WUJIHANDCPP_API void Handler::start_transmit_receive() { impl_->start_transmit_receive(); }
+
 WUJIHANDCPP_API void Handler::read_async_unchecked(
     int storage_id, std::chrono::steady_clock::duration::rep timeout) {
     impl_->read_async_unchecked(storage_id, timeout);
@@ -911,10 +952,21 @@ WUJIHANDCPP_API void Handler::write_async_unchecked(
     impl_->write_async_unchecked(data, storage_id, timeout);
 }
 
+WUJIHANDCPP_API void Handler::enable_host_heartbeat() { impl_->enable_host_heartbeat(); }
+
 WUJIHANDCPP_API void Handler::write_async(
     Buffer8 data, int storage_id, std::chrono::steady_clock::duration::rep timeout,
     void (*callback)(Buffer8 context, bool success), Buffer8 callback_context) {
     impl_->write_async(data, storage_id, timeout, callback, callback_context);
+}
+
+WUJIHANDCPP_API auto Handler::realtime_get_joint_actual_position()
+    -> const std::atomic<double> (&)[5][4] {
+    return impl_->realtime_get_joint_actual_position();
+}
+
+WUJIHANDCPP_API void Handler::realtime_set_joint_target_position(const double (&positions)[5][4]) {
+    impl_->realtime_set_joint_target_position(positions);
 }
 
 WUJIHANDCPP_API void Handler::attach_realtime_controller(


### PR DESCRIPTION
- Introduce device::IController and IControllerWrapper to unify C++/Python controller interfaces and refactor bindings away from the old helper templates
- Detect firmware filter capability (>=6.4.0J), set ControlMode/PDO parameters accordingly, apply PositionFilterCutoffFreq on joints, and fall back to SDK-side LowPass for legacy firmware
- Add RPdoDirectlyDistribute, TPdoProactivelyReport, and HostTimeoutCounter datas;  enable host heartbeat when TPDO proactive reporting is available
- Expose realtime joint read/write APIs in Handler, store PDO data as atomic<double> with corrected sign handling, and support upstream-less writes for firmware-driven filtering
- Expose LowPass cutoff getter and clean up data headers (e.g., remove unused protocol dependency)

Resolve m-6474333937

BREAKING CHANGE:

- Hand::realtime_controller now returns std::unique_ptr<IController> (accepting filter::LowPass); attach_realtime_controller/detach_realtime_controller are removed—C++ callers must adapt (Python surface remains compatible)

## 自测

### 旧固件兼容性

在旧版本固件上工作正常

### 更新驱动板

自动检测并启用 feature `firmware_filter`，工作正常，控制延迟明显降低。

### 更新脊髓板

自动检测并启用 feature `rpdo_directly_distribute` ，工作正常。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 Python 可调用的 set_joint_target_position 和 close 方法
  * get_joint_actual_position 现可直接调用并返回数值数组（无底层控制器时会报错）
  * 暴露并可启动实时传输/接收与主机心跳，提供实时关节位置读写接口
  * 为 LowPass 添加 cutoff_freq 只读访问

* **重构**
  * 控制器对外接口改为包装器形式，简化创建与所有权语义，新增固件感知的实时控制路径与相关数据项扩展

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->