### PR TITLE
fix(version): Handle release marker and rc letters safely

### DIFF
--- a/wujihandcpp/src/data/helper.cpp
+++ b/wujihandcpp/src/data/helper.cpp
@@ -1,4 +1,5 @@
 
+#include <cctype>
 #include <cstddef>
 
 #include <format>
@@ -10,17 +11,23 @@
 namespace wujihandcpp::data {
 
 WUJIHANDCPP_API size_t FirmwareVersionData::string_length() const {
-    if (pre == '\0')
+    if (pre == '~')
         return std::formatted_size("{}.{}.{}", major, minor, patch);
+    else if (auto upper = std::toupper(static_cast<unsigned char>(pre));
+             'A' <= upper && upper <= 'Z')
+        return std::formatted_size("{}.{}.{}-rc{}", major, minor, patch, int(upper - 'A'));
     else
-        return std::formatted_size("{}.{}.{}-{}", major, minor, patch, pre);
+        return std::formatted_size("{}.{}.{}-{}", major, minor, patch, int(pre));
 }
 
 WUJIHANDCPP_API void FirmwareVersionData::write_to_string(char* dst) const {
-    if (pre == '\0')
+    if (pre == '~')
         std::format_to(dst, "{}.{}.{}", major, minor, patch);
+    else if (auto upper = std::toupper(static_cast<unsigned char>(pre));
+             'A' <= upper && upper <= 'Z')
+        std::format_to(dst, "{}.{}.{}-rc{}", major, minor, patch, int(upper - 'A'));
     else
-        std::format_to(dst, "{}.{}.{}-{}", major, minor, patch, pre);
+        std::format_to(dst, "{}.{}.{}-{}", major, minor, patch, int(pre));
 }
 
 } // namespace wujihandcpp::data


### PR DESCRIPTION
- treat '~' as final release with no suffix
- map rc letters case-insensitively to rc0..25
- fallback to emitting ASCII code for other prerelease markers

Resolve f-6513390462

## 思路

1. pre=='~'，表示最终release版本
2. pre==[a,z] || [A,Z]，对应 rc0~rc25
3. 其他情况，fallback回原始 ascii code

## 自测

v1.0.0-~ 被正确映射回版本号 v1.0.0

旧：
```
[info] Using firmware version: 1.0.0-~
```

新：
```
[info] Using firmware version: 1.0.0
```

修改代码展示非大包版本号：

旧：
```
[info] Using firmware version: 3.2.0-A & 6.3.2-G
```

新：
```
[info] Using firmware version: 3.2.0-rc0 & 6.3.2-rc6
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进版本字符串处理逻辑，优化发布版本（RC）标签的生成和显示。
  * 增强对版本后缀格式化的一致性处理。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->