### PR TITLE
feat(hand): Add product serial number (SN) reading support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,6 +82,11 @@ PYBIND11_MODULE(_core, m) {
         "raw_sdo_write", &Hand::raw_sdo_write, py::arg("finger_id"), py::arg("joint_id"),
         py::arg("index"), py::arg("sub_index"), py::arg("data"), py::arg("timeout") = 0.5);
 
+    // Product SN
+    hand.def(
+        "get_product_sn", &Hand::get_product_sn,
+        "Get device product serial number");
+
     using Finger = Wrapper<wujihandcpp::device::Finger>;
     auto finger = py::class_<Finger>(m, "Finger");
     hand.def("finger", &Hand::finger, py::arg("index"), py::keep_alive<0, 1>());

--- a/src/wrapper.hpp
+++ b/src/wrapper.hpp
@@ -287,6 +287,13 @@ public:
             seconds_to_duration(timeout));
     }
 
+    // Get Product SN (0x5202)
+    std::string get_product_sn()
+        requires std::is_same_v<T, wujihandcpp::device::Hand> {
+        py::gil_scoped_release release;
+        return T::read_product_sn();
+    }
+
     template <typename Data>
     static void register_py_interface(py::class_<Wrapper>& py_class, const std::string& name) {
         if constexpr (Data::readable) {

--- a/wujihandcpp/include/wujihandcpp/data/hand.hpp
+++ b/wujihandcpp/include/wujihandcpp/data/hand.hpp
@@ -28,6 +28,15 @@ struct FirmwareDate : ReadOnlyData<device::Hand, 0x5201, 2, uint32_t> {};
 
 struct FullSystemFirmwareVersion : ReadOnlyData<device::Hand, 0x5201, 3, uint32_t> {};
 
+// Product SN (0x5202)
+// SN is stored as 6 x 4-byte chunks (SubIndex 1-6) for Expedited SDO transfer
+struct ProductSNPart1 : ReadOnlyData<device::Hand, 0x5202, 1, uint32_t> {};
+struct ProductSNPart2 : ReadOnlyData<device::Hand, 0x5202, 2, uint32_t> {};
+struct ProductSNPart3 : ReadOnlyData<device::Hand, 0x5202, 3, uint32_t> {};
+struct ProductSNPart4 : ReadOnlyData<device::Hand, 0x5202, 4, uint32_t> {};
+struct ProductSNPart5 : ReadOnlyData<device::Hand, 0x5202, 5, uint32_t> {};
+struct ProductSNPart6 : ReadOnlyData<device::Hand, 0x5202, 6, uint32_t> {};
+
 struct SystemTime : ReadOnlyData<device::Hand, 0x520A, 1, uint32_t> {};
 struct Temperature : ReadOnlyData<device::Hand, 0x520A, 9, float> {};
 struct InputVoltage : ReadOnlyData<device::Hand, 0x520A, 10, float> {};


### PR DESCRIPTION
## Summary
- 新增 ProductSNPart1-6 数据类型，对应 0x5202 寄存器
- 实现 `read_product_sn()` 方法，支持异步批量读取
- 在 Python 绑定中暴露 `get_product_sn()` 接口
- 固件信息日志中显示 SN（如可用）

## Test plan
- [x] 连接设备测试 `hand.get_product_sn()` 返回正确的 SN 字符串
- [x] 验证无 SN 设备返回空字符串

Resolve m-6572327058

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  - Hand 设备现在支持通过 Python 绑定的 get_product_sn 方法获取完整产品序列号。
  - 序列号由设备以六个 4 字节分段读取并组装为 24 字节字符串，包含有效性校验（避免空或全零结果）。
  - 在满足设备/固件版本条件时，固件与日志输出会包含该序列号以便追踪与诊断。
  - 仅新增读取接口与绑定，其他行为保持不变。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->