### PR TITLE
feat(scope): Add TPDO_SCOPE_C12 debug data support with conditional compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,17 @@ endif()
 project(wujihandpy)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# TPDO_SCOPE_C12 debug feature (disabled by default)
+option(WUJI_SCOPE_DEBUG "Enable TPDO_SCOPE_C12 debug feature" OFF)
+
 set(BUILD_STATIC_WUJIHANDCPP ON CACHE BOOL "" FORCE)
 add_subdirectory(wujihandcpp EXCLUDE_FROM_ALL)
+
+# Apply WUJI_SCOPE_DEBUG to both wujihandcpp and _core targets
+if(WUJI_SCOPE_DEBUG)
+    target_compile_definitions(wujihandcpp PRIVATE WUJI_SCOPE_DEBUG)
+    message(STATUS "WUJI_SCOPE_DEBUG enabled")
+endif()
 
 
 # Set C++ standard to C++20
@@ -80,6 +89,11 @@ target_link_libraries(_core PRIVATE pybind11::module)
 
 target_link_directories(_core PRIVATE ${CMAKE_BINARY_DIR}/wujihandcpp)
 target_link_libraries(_core PRIVATE wujihandcpp)
+
+# Apply WUJI_SCOPE_DEBUG to _core target
+if(WUJI_SCOPE_DEBUG)
+    target_compile_definitions(_core PRIVATE WUJI_SCOPE_DEBUG)
+endif()
 
 # The install directory is the output (wheel) directory
 install(TARGETS _core DESTINATION wujihandpy)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,7 +74,8 @@ PYBIND11_MODULE(_core, m) {
     hand.def("start_latency_test", &Hand::start_latency_test);
     hand.def("stop_latency_test", &Hand::stop_latency_test);
 
-    // Scope Mode (TPDO_SCOPE_C12) - 调试数据采集
+#ifdef WUJI_SCOPE_DEBUG
+    // Scope Mode (TPDO_SCOPE_C12)
     hand.def("start_scope_mode", &Hand::start_scope_mode);
     hand.def("stop_scope_mode", &Hand::stop_scope_mode);
     hand.def(
@@ -86,6 +87,7 @@ PYBIND11_MODULE(_core, m) {
         "get_scope_data", &Hand::get_scope_data,
         py::arg("finger_id"), py::arg("joint_id"));
     hand.def("get_all_scope_data", &Hand::get_all_scope_data);
+#endif
 
     // Raw SDO operations for debugging
     hand.def(

--- a/src/wrapper.hpp
+++ b/src/wrapper.hpp
@@ -260,7 +260,7 @@ public:
     void start_latency_test() { T::start_latency_test(); }
     void stop_latency_test() { T::stop_latency_test(); }
 
-    // Scope Mode (TPDO_SCOPE_C12) - only available for Hand
+#ifdef WUJI_SCOPE_DEBUG
     void start_scope_mode() requires std::is_same_v<T, wujihandcpp::device::Hand> {
         py::gil_scoped_release release;
         T::start_scope_mode();
@@ -306,6 +306,7 @@ public:
         py::capsule free(buffer, [](void* ptr) { delete[] static_cast<float*>(ptr); });
         return py::array_t<float>({5, 4, 12}, buffer, free);
     }
+#endif
 
     // Raw SDO operations - only available for Hand
     py::bytes

--- a/wujihandcpp/include/wujihandcpp/device/hand.hpp
+++ b/wujihandcpp/include/wujihandcpp/device/hand.hpp
@@ -231,91 +231,58 @@ public:
         handler_.stop_latency_test();
     }
 
-    // Scope Mode (TPDO_SCOPE_C12) - 调试数据采集模式
-    // 启动 scope 模式，设置 TPdoId SDO 为 0xE2 并创建 vofa_forwarder
-    // 注意：必须先 disable PDO，设置 TPdoId，再 enable PDO，否则 tpdo_request_config() 不会重新配置
+#ifdef WUJI_SCOPE_DEBUG
+    // Scope Mode (TPDO_SCOPE_C12)
+    // Must: disable PDO -> set TPdoId -> enable PDO
     void start_scope_mode() {
-        constexpr char msg1[] = "start_scope_mode: BEGIN CONFIG";
-        logging::log(logging::Level::INFO, msg1, sizeof(msg1) - 1);
-
-        // 1. 先 disable PDO（确保 tpdo_request_config 会被重新调用）
-        constexpr char msg2[] = "start_scope_mode: Step 1 - Disable PDO";
-        logging::log(logging::Level::INFO, msg2, sizeof(msg2) - 1);
+        // 1. Disable PDO
         {
             Latch latch;
             write_async<data::hand::PdoEnabled>(latch, 0);
             latch.wait();
         }
-        constexpr char msg2b[] = "start_scope_mode: PdoEnabled=0 done";
-        logging::log(logging::Level::INFO, msg2b, sizeof(msg2b) - 1);
-
-        // 等待脊髓板停止 PDO sync timer（200ms）
-        constexpr char msg3[] = "start_scope_mode: Wait PDO stop (200ms)";
-        logging::log(logging::Level::INFO, msg3, sizeof(msg3) - 1);
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
-        // 2. 多次写入 TPdoId = 0xE2 确保配置成功
-        constexpr char msg4[] = "start_scope_mode: Step 2 - Write TPdoId=0xE2 (5x)";
-        logging::log(logging::Level::INFO, msg4, sizeof(msg4) - 1);
+        // 2. Set TPdoId = 0xE2 (multiple writes for reliability)
         for (int i = 0; i < 5; i++) {
             {
                 Latch latch;
                 write_async<data::hand::TPdoId>(latch, 0xE2);
                 latch.wait();
             }
-            char buf[64];
-            int len = snprintf(buf, sizeof(buf), "start_scope_mode: TPdoId=0xE2 write #%d done", i + 1);
-            logging::log(logging::Level::INFO, buf, len);
-            // 每次写入后等待 50ms
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
         }
-
-        // 等待脊髓板 rt_task 更新 PDO_Global_Control.global_tpdo_id（200ms）
-        constexpr char msg6[] = "start_scope_mode: Wait rt_task update (200ms)";
-        logging::log(logging::Level::INFO, msg6, sizeof(msg6) - 1);
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
-        // 3. 重新 enable PDO（此时 tpdo_request_config 会使用新的 TPdoId）
-        constexpr char msg7[] = "start_scope_mode: Step 3 - Enable PDO";
-        logging::log(logging::Level::INFO, msg7, sizeof(msg7) - 1);
+        // 3. Enable PDO (triggers tpdo_request_config)
         {
             Latch latch;
             write_async<data::hand::PdoEnabled>(latch, 1);
             latch.wait();
         }
-        constexpr char msg7b[] = "start_scope_mode: PdoEnabled=1 done";
-        logging::log(logging::Level::INFO, msg7b, sizeof(msg7b) - 1);
-
-        // 等待 tpdo_request_config 完成配置（300ms）
-        constexpr char msg8[] = "start_scope_mode: Wait tpdo_request_config (300ms)";
-        logging::log(logging::Level::INFO, msg8, sizeof(msg8) - 1);
         std::this_thread::sleep_for(std::chrono::milliseconds(300));
 
-        constexpr char msg9[] = "start_scope_mode: Call handler_.start_scope_mode()";
-        logging::log(logging::Level::INFO, msg9, sizeof(msg9) - 1);
         handler_.start_scope_mode();
-        constexpr char msg10[] = "start_scope_mode: CONFIG DONE";
-        logging::log(logging::Level::INFO, msg10, sizeof(msg10) - 1);
     }
 
     void stop_scope_mode() {
         handler_.stop_scope_mode();
 
-        // 1. 先 disable PDO
+        // 1. Disable PDO
         {
             Latch latch;
             write_async<data::hand::PdoEnabled>(latch, 0);
             latch.wait();
         }
 
-        // 2. 恢复 SDO TPdoId 为默认 CSP，多次写入确保成功
+        // 2. Restore TPdoId = 0x01
         for (int i = 0; i < 3; i++) {
             Latch latch;
             write_async<data::hand::TPdoId>(latch, 0x01);
             latch.wait();
         }
 
-        // 3. 重新 enable PDO
+        // 3. Enable PDO
         {
             Latch latch;
             write_async<data::hand::PdoEnabled>(latch, 1);
@@ -323,10 +290,6 @@ public:
         }
     }
 
-    // 配置 VOFA UDP 转发
-    // ip: 目标 IP 地址 (如 "192.168.1.100")
-    // port: 目标端口号 (如 1234)
-    // joint_mask: 关节掩码，bit0=finger0_joint0, ..., bit19=finger4_joint3
     bool configure_vofa_forwarder(
         const std::string& ip, uint16_t port, uint32_t joint_mask = 0xFFFFF) {
         return handler_.configure_vofa_forwarder(ip, port, joint_mask);
@@ -336,15 +299,14 @@ public:
 
     void set_vofa_joint_mask(uint32_t mask) { handler_.set_vofa_joint_mask(mask); }
 
-    // 获取指定关节的 scope 数据 (12 个 float)
     std::array<float, 12> get_scope_data(int finger_id, int joint_id) {
         return handler_.get_scope_data(finger_id, joint_id);
     }
 
-    // 获取所有关节的 scope 数据 [5][4][12]
     std::array<std::array<std::array<float, 12>, 4>, 5> get_all_scope_data() {
         return handler_.get_all_scope_data();
     }
+#endif
 
     void disable_thread_safe_check() { handler_.disable_thread_safe_check(); }
 
@@ -480,7 +442,11 @@ private:
             write_async<data::joint::ControlMode>(latch, 5);
             write_async<data::hand::RPdoId>(latch, 0x01);
             if (enable_upstream)
-                write_async<data::hand::TPdoId>(latch, 0xE2);  // 使用 TPDO_SCOPE_C12
+#ifdef WUJI_SCOPE_DEBUG
+                write_async<data::hand::TPdoId>(latch, 0xE2);  // Request TPDO_SCOPE_C12
+#else
+                write_async<data::hand::TPdoId>(latch, 0x01);  // Request TPDO_CSP
+#endif
             else
                 write_async<data::hand::TPdoId>(latch, 0x00);
             write_async<data::hand::PdoInterval>(latch, 2000);

--- a/wujihandcpp/include/wujihandcpp/protocol/handler.hpp
+++ b/wujihandcpp/include/wujihandcpp/protocol/handler.hpp
@@ -125,23 +125,20 @@ public:
         uint16_t index, uint8_t sub_index, std::span<const std::byte> data,
         std::chrono::steady_clock::duration timeout);
 
-    // Scope mode (TPDO_SCOPE_C12) 调试模式
+#ifdef WUJI_SCOPE_DEBUG
+    // Scope mode (TPDO_SCOPE_C12)
     WUJIHANDCPP_API void start_scope_mode();
     WUJIHANDCPP_API void stop_scope_mode();
 
-    // VOFA UDP 转发配置
-    // ip: 目标 IP 地址
-    // port: 目标端口号
-    // joint_mask: 关节掩码，bit0=finger0_joint0, bit19=finger4_joint3
+    // VOFA UDP forwarding
     WUJIHANDCPP_API bool configure_vofa_forwarder(
         const std::string& ip, uint16_t port, uint32_t joint_mask = 0xFFFFF);
-
     WUJIHANDCPP_API void set_vofa_enabled(bool enabled);
     WUJIHANDCPP_API void set_vofa_joint_mask(uint32_t mask);
 
-    // 获取 scope 数据
     WUJIHANDCPP_API std::array<float, 12> get_scope_data(int finger_id, int joint_id);
     WUJIHANDCPP_API std::array<std::array<std::array<float, 12>, 4>, 5> get_all_scope_data();
+#endif
 
 private:
     class Impl;

--- a/wujihandcpp/src/protocol/frame_builder.hpp
+++ b/wujihandcpp/src/protocol/frame_builder.hpp
@@ -87,8 +87,12 @@ private:
             uint16_t max_receive_window : 10;
             uint16_t frame_length       : 6;
         } description{
-            // 增大接收窗口以支持 TPDO_SCOPE_C12 (需要约 968 字节, 968/4=242, 使用 256)
-            .max_receive_window = 0x100, .frame_length = (uint8_t)(compressed_frame_length - 1)};
+#ifdef WUJI_SCOPE_DEBUG
+            .max_receive_window = 0x100,  // For TPDO_SCOPE_C12 (~968 bytes)
+#else
+            .max_receive_window = 0xA0,
+#endif
+            .frame_length = (uint8_t)(compressed_frame_length - 1)};
         header.description = std::bit_cast<int16_t>(description);
 
         logger_.trace(

--- a/wujihandcpp/src/protocol/protocol.hpp
+++ b/wujihandcpp/src/protocol/protocol.hpp
@@ -132,19 +132,6 @@ PACKED_STRUCT(LatencyTestResult {
     uint32_t t_usb_rx_tx;
 });
 
-// TPDO_SCOPE_C12 (0xE2) 调试数据结构
-// 每个关节返回 12 个 float 调试值
-PACKED_STRUCT(ScopeC12JointData {
-    float values[12];
-});
-
-// 与固件 Spinal_TPDO_Scope_C12_T 对应
-PACKED_STRUCT(ScopeC12Result {
-    uint16_t padding;                     // 固件填充字段
-    ScopeC12JointData joint_datas[5][4];  // 5 fingers × 4 joints
-    uint32_t suffix;                      // VOFA suffix (0x7f800000)
-});
-
 }; // namespace pdo
 
 PACKED_STRUCT(CrcCheck { uint16_t value; });

--- a/wujihandcpp/src/protocol/scope/scope_pdo.hpp
+++ b/wujihandcpp/src/protocol/scope/scope_pdo.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+// TPDO_SCOPE_C12 (0xE2) protocol definitions
+// Only included when WUJI_SCOPE_DEBUG is defined
+
+#include "protocol/protocol.hpp"
+
+namespace wujihandcpp::protocol::pdo {
+
+// 12 floats per joint for debug data
+PACKED_STRUCT(ScopeC12JointData {
+    float values[12];
+});
+
+// Matches firmware Spinal_TPDO_Scope_C12_T
+PACKED_STRUCT(ScopeC12Result {
+    uint16_t padding;
+    ScopeC12JointData joint_datas[5][4];  // 5 fingers x 4 joints
+    uint32_t suffix;                       // VOFA tail (0x7F800000)
+});
+
+} // namespace wujihandcpp::protocol::pdo

--- a/wujihandcpp/src/transport/usb.cpp
+++ b/wujihandcpp/src/transport/usb.cpp
@@ -445,8 +445,11 @@ private:
     static constexpr unsigned char out_endpoint_ = 0x01;
     static constexpr unsigned char in_endpoint_ = 0x81;
 
-    // 增大传输缓冲区以支持 TPDO_SCOPE_C12 (需要约 978 字节)
-    static constexpr int max_transfer_length_ = 2048;
+#ifdef WUJI_SCOPE_DEBUG
+    static constexpr int max_transfer_length_ = 2048;  // For TPDO_SCOPE_C12 (~978 bytes)
+#else
+    static constexpr int max_transfer_length_ = 512;
+#endif
 
     static constexpr size_t transmit_transfer_count_ = 64;
     static constexpr size_t receive_transfer_count_ = 4;


### PR DESCRIPTION
## Summary
- Add TPDO_SCOPE_C12 (0xE2) support for joint-level debug data (12 floats per joint)
- Isolate scope feature with `WUJI_SCOPE_DEBUG` CMake option (OFF by default)
- Add VofaForwarder for real-time waveform visualization via UDP

## Changes
- **CMakeLists.txt**: Add `WUJI_SCOPE_DEBUG` option with `target_compile_definitions`
- **Conditional compilation**:
  - TPdoId: 0x01 (default) vs 0xE2 (debug)
  - read_id: 0x01 (default) vs 0xE2 (debug)
  - max_receive_window: 0xA0 (default) vs 0x100 (debug)
  - max_transfer_length_: 512 (default) vs 2048 (debug)
- **Code organization**: Move scope code to `scope/` directory

## Compatibility
- Default compilation is identical to original behavior
- No extra compile flags needed for normal usage

## Self-Testing

### Build Verification
| Mode | Build Result | Scope Methods |
|------|--------------|---------------|
| Default (`cmake ..`) | ✅ Success | ❌ None (correct) |
| Debug (`cmake .. -DWUJI_SCOPE_DEBUG=ON`) | ✅ Success | ✅ 7 methods |

**Default mode**:
```
Default build: scope methods present = False
Scope methods: []
```

**Debug mode**:
```
WUJI_SCOPE_DEBUG build: scope methods present = True
Methods: ['configure_vofa_forwarder', 'get_all_scope_data', 'get_scope_data',
          'set_vofa_enabled', 'set_vofa_joint_mask', 'start_scope_mode', 'stop_scope_mode']
```

### Default Mode Position Feedback Test
```
[Realtime] Start realtime control (enable_upstream=True)...
  t=1.0s  F2J1: target=0.0000, actual=0.1806
  t=2.0s  F2J1: target=0.0000, actual=0.1792

[Result]
  Total feedback: 249
  Valid feedback: 248
  Valid rate: 99.6%

✅ Position feedback normal!
```

### Debug Mode Functional Test
**Environment**: Left hand, Spinal FW 3.2.1-A, Driver FW 6.4.0-L

| Test Item | Result |
|-----------|--------|
| TPdoId config | ✅ 0x01 → 0xE2 success |
| TPDO_SCOPE_C12 receive | ✅ read_id=0xE2 correct |
| Scope data parsing | ✅ 12 floats valid |
| VOFA UDP forwarding | ✅ Waveform display normal |

**Scope data sample** (F2J1):
```
t=6.0s  target=0.3996 rad  [✓ valid]
        scope[0:6]: -21.79, 1.00, 1.00, -0.36, -0.29, -21.78
        Encoder: enc1=-21.78° enc2=-23.08°
```

Resolve m-6545798554

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加可选的调试示波器模式功能，支持启动和停止示波器监测
  * 新增 VOFA 数据转发器，通过 UDP 协议转发示波器数据用于调试监控
  * 添加示波器数据查询接口和关节选择掩码配置功能
  * 支持配置转发目标（IP 地址和端口号）

* **其他改动**
  * 扩展底层通信缓冲区以支持调试功能

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->