### PR TITLE
fix(headers): Fix C++11 ODR issue with default_timeout

### DIFF
--- a/wujihandcpp/include/wujihandcpp/device/data_operator.hpp
+++ b/wujihandcpp/include/wujihandcpp/device/data_operator.hpp
@@ -40,12 +40,13 @@ class DataOperator {
     }
 
 public:
-    static constexpr std::chrono::steady_clock::duration default_timeout =
-        std::chrono::milliseconds(500);
+    static std::chrono::steady_clock::duration default_timeout() {
+        return std::chrono::milliseconds(500);
+    }
 
     template <typename Data>
     SDK_CPP20_REQUIRES(Data::readable)
-    auto read(std::chrono::steady_clock::duration timeout = default_timeout) ->
+    auto read(std::chrono::steady_clock::duration timeout = default_timeout()) ->
         typename std::enable_if<
             std::is_same<typename Data::Base, T>::value, typename Data::ValueType>::type {
         static_assert(Data::readable, "");
@@ -58,7 +59,7 @@ public:
 
     template <typename Data>
     SDK_CPP20_REQUIRES(Data::readable)
-    auto read(std::chrono::steady_clock::duration timeout = default_timeout) ->
+    auto read(std::chrono::steady_clock::duration timeout = default_timeout()) ->
         typename std::enable_if<!std::is_same<typename Data::Base, T>::value, void>::type {
         static_assert(Data::readable, "");
 
@@ -69,7 +70,7 @@ public:
 
     template <typename Data>
     SDK_CPP20_REQUIRES(Data::readable)
-    void read_async(Latch& latch, std::chrono::steady_clock::duration timeout = default_timeout) {
+    void read_async(Latch& latch, std::chrono::steady_clock::duration timeout = default_timeout()) {
         static_assert(Data::readable, "");
 
         Handler& handler = static_cast<T*>(this)->handler_;
@@ -89,7 +90,7 @@ public:
         Data::readable && sizeof(F) <= 8 && alignof(F) <= 8
         && std::is_trivially_copyable_v<F> && std::is_trivially_destructible_v<F>
         && requires(bool success, const F& f) { f(success); })
-    void read_async(const F& f, std::chrono::steady_clock::duration timeout = default_timeout) {
+    void read_async(const F& f, std::chrono::steady_clock::duration timeout = default_timeout()) {
         static_assert(Data::readable, "");
 
         static_assert(sizeof(F) <= 8, "");
@@ -108,7 +109,7 @@ public:
 
     template <typename Data>
     SDK_CPP20_REQUIRES(Data::readable)
-    void read_async_unchecked(std::chrono::steady_clock::duration timeout = default_timeout) {
+    void read_async_unchecked(std::chrono::steady_clock::duration timeout = default_timeout()) {
         static_assert(Data::readable, "");
 
         Handler& handler = static_cast<T*>(this)->handler_;
@@ -132,7 +133,7 @@ public:
     SDK_CPP20_REQUIRES(Data::writable)
     void write(
         typename Data::ValueType value,
-        std::chrono::steady_clock::duration timeout = default_timeout) {
+        std::chrono::steady_clock::duration timeout = default_timeout()) {
         static_assert(Data::writable, "");
 
         Latch latch;
@@ -144,7 +145,7 @@ public:
     SDK_CPP20_REQUIRES(Data::writable)
     void write_async(
         Latch& latch, typename Data::ValueType value,
-        std::chrono::steady_clock::duration timeout = default_timeout) {
+        std::chrono::steady_clock::duration timeout = default_timeout()) {
         static_assert(Data::writable, "");
 
         Handler& handler = static_cast<T*>(this)->handler_;
@@ -166,7 +167,7 @@ public:
         && requires(bool success, const F& f) { f(success); })
     void write_async(
         const F& f, typename Data::ValueType value,
-        std::chrono::steady_clock::duration timeout = default_timeout) {
+        std::chrono::steady_clock::duration timeout = default_timeout()) {
         static_assert(Data::writable, "");
 
         static_assert(sizeof(F) <= 8, "");
@@ -187,7 +188,7 @@ public:
     SDK_CPP20_REQUIRES(Data::writable)
     void write_async_unchecked(
         typename Data::ValueType value,
-        std::chrono::steady_clock::duration timeout = default_timeout) {
+        std::chrono::steady_clock::duration timeout = default_timeout()) {
         static_assert(Data::writable, "");
 
         Handler& handler = static_cast<T*>(this)->handler_;

--- a/wujihandcpp/include/wujihandcpp/device/hand.hpp
+++ b/wujihandcpp/include/wujihandcpp/device/hand.hpp
@@ -296,14 +296,14 @@ public:
     // joint_id: 0-3 for joints (ignored when finger_id=-1)
     std::vector<uint8_t> raw_sdo_read(
         int finger_id, int joint_id, uint16_t index, uint8_t sub_index,
-        std::chrono::steady_clock::duration timeout = default_timeout) {
+        std::chrono::steady_clock::duration timeout = default_timeout()) {
         uint16_t full_index = index + calculate_index_offset(finger_id, joint_id);
         return handler_.raw_sdo_read(full_index, sub_index, timeout);
     }
 
     void raw_sdo_write(
         int finger_id, int joint_id, uint16_t index, uint8_t sub_index, const void* data,
-        size_t size, std::chrono::steady_clock::duration timeout = default_timeout) {
+        size_t size, std::chrono::steady_clock::duration timeout = default_timeout()) {
         uint16_t full_index = index + calculate_index_offset(finger_id, joint_id);
         handler_.raw_sdo_write(full_index, sub_index, data, size, timeout);
     }

--- a/wujihandcpp/tests/cpp11_compat/main.cpp
+++ b/wujihandcpp/tests/cpp11_compat/main.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 
 #include <wujihandcpp/device/controller.hpp>
+#include <wujihandcpp/device/hand.hpp>
 #include <wujihandcpp/filter/low_pass.hpp>
 
 int main() {
@@ -42,6 +43,15 @@ int main() {
     (void)sizeof(device::IController);
     (void)sizeof(device::IRealtimeController);
     (void)sizeof(device::IRealtimeController::JointPositions);
+
+    // Test 5: default_timeout() function (C++11 ODR compatibility)
+    // In C++11/14, static constexpr members need out-of-class definition when ODR-used.
+    // Using a function instead of a variable avoids this issue.
+    auto timeout = device::DataOperator<device::Hand>::default_timeout();
+    if (timeout != std::chrono::milliseconds(500)) {
+        std::printf("FAIL: default_timeout() returned unexpected value\n");
+        return 1;
+    }
 
     std::printf("OK: All C++11 compatibility tests passed\n");
     return 0;


### PR DESCRIPTION
## Summary
- 修复 C++11/14 的 ODR (One Definition Rule) 问题
- 将 `static constexpr default_timeout` 变量改为 `static default_timeout()` 函数
- 添加测试用例验证 C++11 ODR 兼容性

## 问题原因
在 C++11/14 中，`static constexpr` 成员变量如果被 ODR-used（例如作为函数默认参数），需要在类外显式定义。C++17 后 `static constexpr` 隐式是 `inline` 的，不需要类外定义。

当客户用 C++11/14 编译时，会出现链接错误：
```
undefined reference to `wujihandcpp::device::DataOperator<...>::default_timeout'
```

## Test plan
- [x] 本地 C++11 编译测试通过
- [x] 本地 C++20 编译测试通过
- [x] CI C++11 兼容性测试覆盖此场景

Resolve f-6599860180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **重构**
  * 优化了超时值的获取方式，确保兼容性。
  * 更新了相关方法的默认参数配置。

* **测试**
  * 添加 C++11 兼容性验证测试。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->