### PR TITLE
docs: remove internal debug field joint_sin_level from API reference

### DIFF
--- a/docs/external/en/api-reference.mdx
+++ b/docs/external/en/api-reference.mdx
@@ -50,13 +50,6 @@ This field is used to set the control mode of the joint.
 
 > Note: The mode switches automatically, and this field should not be modified under normal circumstances.
 
-#### joint_sin_level
-This field is used to set the sine wave excitation level of the joint drive.
-- **Type**: `uint16`
-- **Read/Write**: Write-only
-
-> Note: This field is used for internal debugging and should not be modified under normal circumstances.
-
 #### joint_effort_limit
 This field is used to set the upper effort limit allowed by the joint.
 - **Type**: `float64`
@@ -413,19 +406,6 @@ This field records the lower position limit of the joint.
 
 ##### Other Parameter Configuration
 
-- `write_joint_sin_level(value, timeout=0.5) -> None`
-  *Synchronously set all joint sine wave excitation levels*
-- `write_joint_sin_level(value_array, timeout=0.5) -> None`
-  *Synchronously batch set each joint sine wave excitation level*
-- `write_joint_sin_level_async(value, timeout=0.5) -> Awaitable[None]`
-  *Asynchronously set all joint sine wave excitation levels*
-- `write_joint_sin_level_async(value_array, timeout=0.5) -> Awaitable[None]`
-  *Asynchronously batch set each joint sine wave excitation level*
-- `write_joint_sin_level_unchecked(value, timeout=0.5) -> None`
-  *Non-blocking set all joint sine wave excitation levels*
-- `write_joint_sin_level_unchecked(value_array, timeout=0.5) -> None`
-  *Non-blocking batch set each joint sine wave excitation level*
-
 - `write_joint_reset_error(value, timeout=0.5) -> None`
   *Synchronously reset all joint errors*
 - `write_joint_reset_error(value_array, timeout=0.5) -> None`
@@ -601,19 +581,6 @@ This field records the lower position limit of the joint.
 
 ##### Other Parameter Configuration
 
-- `write_joint_sin_level(value, timeout=0.5) -> None`
-  *Synchronously set all joint sine wave excitation levels of the finger*
-- `write_joint_sin_level(value_array, timeout=0.5) -> None`
-  *Synchronously batch set each joint sine wave excitation level of the finger*
-- `write_joint_sin_level_async(value, timeout=0.5) -> Awaitable[None]`
-  *Asynchronously set all joint sine wave excitation levels of the finger*
-- `write_joint_sin_level_async(value_array, timeout=0.5) -> Awaitable[None]`
-  *Asynchronously batch set each joint sine wave excitation level of the finger*
-- `write_joint_sin_level_unchecked(value, timeout=0.5) -> None`
-  *Non-blocking set all joint sine wave excitation levels of the finger*
-- `write_joint_sin_level_unchecked(value_array, timeout=0.5) -> None`
-  *Non-blocking batch set each joint sine wave excitation level of the finger*
-
 - `write_joint_reset_error(value, timeout=0.5) -> None`
   *Synchronously reset all joint errors of the finger*
 - `write_joint_reset_error(value_array, timeout=0.5) -> None`
@@ -756,13 +723,6 @@ This field records the lower position limit of the joint.
   *Non-blocking set joint effort limit*
 
 ##### Other Parameter Configuration
-
-- `write_joint_sin_level(value, timeout=0.5) -> None`
-  *Synchronously set joint sine wave excitation level*
-- `write_joint_sin_level_async(value, timeout=0.5) -> Awaitable[None]`
-  *Asynchronously set joint sine wave excitation level*
-- `write_joint_sin_level_unchecked(value, timeout=0.5) -> None`
-  *Non-blocking set joint sine wave excitation level*
 
 - `write_joint_reset_error(value, timeout=0.5) -> None`
   *Synchronously reset joint error*

--- a/docs/external/zh/api-reference.mdx
+++ b/docs/external/zh/api-reference.mdx
@@ -50,13 +50,6 @@ description: Wuji Hand SDK (wujihandpy) 完整 API 参考，包括 Hand、Finger
 
 > 说明：模式会自动切换，一般情况下不应修改该字段。
 
-#### joint_sin_level
-该字段用于设置关节驱动的正弦波激励档位。  
-- **类型**：`uint16`
-- **读写属性**：只写
-
-> 说明：该字段用于内部调试，一般情况下不应修改该字段。
-
 #### joint_effort_limit
 该字段用于设置关节允许的 effort 上限。
 - **类型**：`float64`
@@ -413,19 +406,6 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 
 ##### 其他参数配置
 
-- `write_joint_sin_level(value, timeout=0.5) -> None`
-  *同步设置所有关节正弦波激励档位*
-- `write_joint_sin_level(value_array, timeout=0.5) -> None`
-  *同步批量设置各关节正弦波激励档位*
-- `write_joint_sin_level_async(value, timeout=0.5) -> Awaitable[None]`
-  *异步设置所有关节正弦波激励档位*
-- `write_joint_sin_level_async(value_array, timeout=0.5) -> Awaitable[None]`
-  *异步批量设置各关节正弦波激励档位*
-- `write_joint_sin_level_unchecked(value, timeout=0.5) -> None`
-  *非阻塞设置所有关节正弦波激励档位*
-- `write_joint_sin_level_unchecked(value_array, timeout=0.5) -> None`
-  *非阻塞批量设置各关节正弦波激励档位*
-
 - `write_joint_reset_error(value, timeout=0.5) -> None`
   *同步重置所有关节错误*
 - `write_joint_reset_error(value_array, timeout=0.5) -> None`
@@ -601,19 +581,6 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 
 ##### 其他参数配置
 
-- `write_joint_sin_level(value, timeout=0.5) -> None`
-  *同步设置手指所有关节正弦波激励档位*
-- `write_joint_sin_level(value_array, timeout=0.5) -> None`
-  *同步批量设置手指各关节正弦波激励档位*
-- `write_joint_sin_level_async(value, timeout=0.5) -> Awaitable[None]`
-  *异步设置手指所有关节正弦波激励档位*
-- `write_joint_sin_level_async(value_array, timeout=0.5) -> Awaitable[None]`
-  *异步批量设置手指各关节正弦波激励档位*
-- `write_joint_sin_level_unchecked(value, timeout=0.5) -> None`
-  *非阻塞设置手指所有关节正弦波激励档位*
-- `write_joint_sin_level_unchecked(value_array, timeout=0.5) -> None`
-  *非阻塞批量设置手指各关节正弦波激励档位*
-
 - `write_joint_reset_error(value, timeout=0.5) -> None`
   *同步重置手指所有关节错误*
 - `write_joint_reset_error(value_array, timeout=0.5) -> None`
@@ -756,13 +723,6 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
   *非阻塞设置关节 effort limit*
 
 ##### 其他参数配置
-
-- `write_joint_sin_level(value, timeout=0.5) -> None`
-  *同步设置关节正弦波激励档位*
-- `write_joint_sin_level_async(value, timeout=0.5) -> Awaitable[None]`
-  *异步设置关节正弦波激励档位*
-- `write_joint_sin_level_unchecked(value, timeout=0.5) -> None`
-  *非阻塞设置关节正弦波激励档位*
 
 - `write_joint_reset_error(value, timeout=0.5) -> None`
   *同步重置关节错误*


### PR DESCRIPTION
## Summary
- Remove `joint_sin_level` field and all related methods (`write_joint_sin_level`, `_async`, `_unchecked`) from API reference
- The field is self-documented as "for internal debugging" and should not appear in user-facing documentation

## Context
Part of internal exposure audit — fields marked as internal debugging should not be exposed in external API documentation.

## Test plan
- [ ] Verify api-reference.mdx renders correctly
- [ ] Confirm no broken cross-references in tutorial.mdx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 文档

* **API 变更** - 移除了关节正弦波激励功能相关的文档和 API 方法（包括同步、异步和检查变体），相应的 API 文档已更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->