### PR TITLE
refactor: report specific disconnected joints on initialization failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Initialization error messages now report specific disconnected joints (e.g. `finger(2).joint(1)`) instead of generic "joint configuration incomplete"
+
 ### Added
 
 - **Zenoh Bridge (Python)**: standalone bridge process exposing WujiHand via Zenoh network protocol (`bridge/python/hand_zenoh_bridge.py`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Initialization error messages now report specific disconnected joints (e.g. `finger(2).joint(1)`) instead of generic "joint configuration incomplete"
+- Initialization failure now reports specific disconnected joints (e.g. `finger(2).joint(1)`) instead of generic error message
 
 ### Added
 

--- a/wujihandcpp/include/wujihandcpp/device/hand.hpp
+++ b/wujihandcpp/include/wujihandcpp/device/hand.hpp
@@ -62,7 +62,17 @@ public:
             latch.wait();
 
         } catch (const TimeoutError&) {
-            throw TimeoutError("Hand initialization timed out: joint configuration incomplete");
+            std::string disconnected;
+            for (int i = 0; i < sub_count_; i++)
+                for (int j = 0; j < Finger::sub_count_; j++)
+                    if (finger(i).joint(j).get<data::joint::FirmwareVersion>() == 0)
+                        disconnected += " finger(" + std::to_string(i) + ").joint(" + std::to_string(j) + ")";
+
+            if (!disconnected.empty())
+                throw TimeoutError(
+                    "Failed to initialize hand: joint(s) not responding:" + disconnected);
+
+            throw TimeoutError("Failed to initialize hand: no response from device");
         }
     };
 

--- a/wujihandcpp/include/wujihandcpp/device/hand.hpp
+++ b/wujihandcpp/include/wujihandcpp/device/hand.hpp
@@ -62,17 +62,22 @@ public:
             latch.wait();
 
         } catch (const TimeoutError&) {
+            int disconnected_count = 0;
             std::string disconnected;
             for (int i = 0; i < sub_count_; i++)
                 for (int j = 0; j < Finger::sub_count_; j++)
-                    if (finger(i).joint(j).get<data::joint::FirmwareVersion>() == 0)
+                    if (finger(i).joint(j).get<data::joint::FirmwareVersion>() == 0) {
+                        disconnected_count++;
                         disconnected += " finger(" + std::to_string(i) + ").joint(" + std::to_string(j) + ")";
+                    }
 
-            if (!disconnected.empty())
+            if (disconnected_count == 0)
+                throw TimeoutError("Failed to initialize hand: configuration timed out");
+            else if (disconnected_count < sub_count_ * Finger::sub_count_)
                 throw TimeoutError(
                     "Failed to initialize hand: joint(s) not responding:" + disconnected);
-
-            throw TimeoutError("Failed to initialize hand: no response from device");
+            else
+                throw TimeoutError("Failed to initialize hand: no response from device");
         }
     };
 


### PR DESCRIPTION
## Summary
- 初始化超时时，检查每个关节的固件版本缓存，精确报出掉线关节（如 `finger(2).joint(1)`）
- 所有关节均无响应时，报 `no response from device`
- 替换原先笼统的 `joint configuration incomplete` 提示

## Test plan
- [x] 正常连接：初始化成功，无异常
- [x] Mock 关节掉线：报出具体掉线关节编号

Resolve swd-929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 改进了初始化失败时的诊断提示：当关节无响应时，错误信息会精确列出具体不可响应的关节标识，便于快速定位问题；当所有关节均无响应时，会明确提示设备无响应；若无特定关节被识别为异常，则仍保留通用的超时初始化提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->