### PR TITLE
docs: fix handedness value mapping (0=right, 1=left)

### DIFF
--- a/docs/external/en/api-reference.mdx
+++ b/docs/external/en/api-reference.mdx
@@ -9,7 +9,7 @@ This section introduces all available data fields in wujihandpy.
 ### 1.1 Hand Layer
 This layer contains device-unique general fields, such as handedness, firmware version, etc.
 #### handedness
-This field indicates the handedness of the dexterous hand (left/right hand, 0 for left, 1 for right).
+This field indicates the handedness of the dexterous hand (left/right hand, 0 for right, 1 for left).
 - **Type**: `uint8`
 - **Read/Write**: Read-only
 #### firmware_version
@@ -225,7 +225,7 @@ This field records the lower position limit of the joint.
   *Get cached firmware compilation date*
 
 - `read_handedness(timeout=0.5) -> uint8`
-  *Synchronously read left/right hand identifier (0=left, 1=right)*
+  *Synchronously read left/right hand identifier (0=right, 1=left)*
 - `read_handedness_async(timeout=0.5) -> Awaitable[uint8]`
   *Asynchronously read left/right hand identifier*
 - `read_handedness_unchecked(timeout=0.5) -> None`

--- a/docs/external/zh/api-reference.mdx
+++ b/docs/external/zh/api-reference.mdx
@@ -9,7 +9,7 @@ description: Wuji Hand SDK (wujihandpy) 完整 API 参考，包括 Hand、Finger
 ### 1.1 Hand 层
 该层包含整手设备唯一的通用字段，例如手性、固件版本等。  
 #### handedness
-该字段表示灵巧手的手性（左/右手，0 表示左手，1 表示右手）。  
+该字段表示灵巧手的手性（左/右手，0 表示右手，1 表示左手）。  
 - **类型**：`uint8`
 - **读写属性**：只读
 #### firmware_version
@@ -225,7 +225,7 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
   *获取缓存的固件编译日期*
 
 - `read_handedness(timeout=0.5) -> uint8`
-  *同步读取左右手标识（0=左，1=右）*
+  *同步读取左右手标识（0=右，1=左）*
 - `read_handedness_async(timeout=0.5) -> Awaitable[uint8]`
   *异步读取左右手标识*
 - `read_handedness_unchecked(timeout=0.5) -> None`


### PR DESCRIPTION
## 问题
`docs/external/{en,zh}/api-reference.mdx` 中 `handedness` 字段的值映射描述反了，原文说 `0=左, 1=右`，实际固件语义为 `0=右, 1=左`。

## 变更
- `docs/external/zh/api-reference.mdx`：字段说明与 `read_handedness` 方法描述各 1 处
- `docs/external/en/api-reference.mdx`：同上

## 自测
- 已全局 grep `handedness` 及 `左/右` 映射关键字，确认无其他位置遗漏
- `introduction.mdx` 只描述"手性（左/右手）"未给出 0/1 映射，无需改动
- C++/Python 代码层无此映射描述，无需改动

相关：SWD-938

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新了API参考文档的英文和中文版本，澄清了手势识别字段的数值标识符对应关系。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->