### PR TITLE
feat(bridge): publish joint_states for URDF live-sync in Wuji Studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Initialization failure now reports specific disconnected joints (e.g. `finger(2).joint(1)`) instead of generic error message
+- **Zenoh Bridge (Python)**: `realtime_controller` LowPass cutoff is now configurable via `--filter-cutoff` (default `5.0` Hz, matching `example/3.realtime.py`); previously hard-coded at 10000 Hz. Pass `--filter-cutoff 10000` to restore the prior near-passthrough behavior.
+- **Zenoh Bridge (Python)**: `--side {left,right}` is now a required CLI argument so the published `joint_states` joint names match the URDF loaded downstream.
 
 ### Added
 
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python/C++ fire-and-forget target_position subscriber for low-latency PUT writes
 - 37 unit tests for bridge protocol, resources, timestamps, and control ownership
 - `bridge/README.md` with architecture, usage, and resource documentation
+- **Zenoh Bridge (Python)**: `joint_states` SUB topic (`sensor_msgs/JointState`) — flat row-major projection of `joint/actual_position` with joint names matching [`wuji-hand-description`](https://github.com/wuji-technology/wuji-hand-description) URDFs, enabling live URDF visualization in Wuji Studio's 3D panel. Published without the timestamp envelope so the schema title stays exactly `sensor_msgs/JointState`; ordering is carried in `header.stamp` via a bridge-side monotonic clock.
 
 ## [1.5.1] - 2026-02-02
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -28,15 +28,28 @@ cd wujihandpy
 source .venv/bin/activate
 pip install eclipse-zenoh numpy
 
-# Start the bridge (device must be connected over USB, --pub-rate is required)
-PYTHONPATH=. python -m bridge.python.hand_zenoh_bridge --pub-rate 1000
+# Start the bridge (device over USB; --pub-rate and --side are required)
+PYTHONPATH=. python -m bridge.python.hand_zenoh_bridge --pub-rate 1000 --side left
 
 # Full arguments
 PYTHONPATH=. python -m bridge.python.hand_zenoh_bridge \
     --sn "DEVICE_SN" \
     --pub-rate 1000 \
+    --side left \
     --log-level DEBUG
 ```
+
+`--side {left,right}` selects which set of joint names is published on
+`joint_states` (`left_finger{1..5}_joint{1..4}` or `right_...`). It must match
+the URDF loaded downstream (e.g. in Wuji Studio).
+
+`--filter-cutoff <Hz>` (default `5.0`) tunes the internal
+`realtime_controller` LowPass cutoff. The filter runs at PDO 1 kHz and
+smooths target_position writes from the bridge's 100 Hz feed loop out to the
+1 ms PDO tick, so remote clients can send step targets at any rate without
+stair-stepping the motors. Lower the cutoff for smoother motion, raise it
+(e.g. `10000`) to approximate passthrough if you prefer to pre-filter on the
+client.
 
 ### C++ Bridge
 
@@ -131,6 +144,12 @@ finally:
 | `joint/lower_limit` | 5x4 float | Joint lower limit |
 | `joint/bus_voltage` | 5x4 float | Joint bus voltage |
 
+### SUB-only Resources
+
+| Path | Type / Schema title | Description |
+|------|---------------------|-------------|
+| `joint_states` | `sensor_msgs/JointState` — `{name: string[20], position: number[20]}` | Flat row-major projection of `joint/actual_position`. Joint names follow `{side}_finger{1..5}_joint{1..4}`, matching [`wuji-hand-description`](https://github.com/wuji-technology/wuji-hand-description) URDFs. **Published without the timestamp envelope** so downstream consumers (e.g. Wuji Studio's 3D panel) can identify it directly by schema title and drive a URDF visualization. |
+
 ### SET Resources
 
 These resources require control ownership.
@@ -168,6 +187,19 @@ SUB resources are published as:
 Control-changing requests must attach the requester identity in the Zenoh attachment. The bridge verifies that:
 - `@control` acquire/release uses the same requester in both payload and attachment
 - fire-and-forget `joint/target_position` PUT uses the current control owner's requester id in the attachment
+
+## Visualize in Wuji Studio
+
+With the bridge running, you can view the hand in Studio's 3D panel without
+touching the control path:
+
+1. Open Wuji Studio. When it discovers this bridge over Zenoh, the topic
+   `/wuji/{sn}/joint_states` becomes subscribable (schema
+   `sensor_msgs/JointState`).
+2. Open a **3D** panel → **Add URDF** → source **filePath** → point to
+   `wuji-hand-description/urdf/left.urdf` (or `right.urdf` — must match the
+   `--side` you launched the bridge with).
+3. The 3D panel auto-subscribes `joint_states` and animates the URDF.
 
 ## Tests
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -164,11 +164,11 @@ These resources require control ownership.
 
 ## Data Format
 
-GET/queryable replies always use the resource's original schema. Only SUB streams are wrapped in a timestamped envelope.
+GET/queryable replies always use the resource's original schema. Most SUB streams are wrapped in a timestamped envelope, with one exception called out below.
 
 ### SUB Stream Format
 
-SUB resources are published as:
+By default, SUB resources are published as a timestamped envelope:
 
 ```json
 {
@@ -176,6 +176,8 @@ SUB resources are published as:
   "data": [[0.1, 0.2, 0.3, 0.4], "..."]
 }
 ```
+
+**Exception:** `joint_states` is published raw (no envelope) so its schema title remains exactly `sensor_msgs/JointState` for downstream consumers that key on schema name (e.g. Wuji Studio's 3D panel). Ordering for this topic is carried in the standard ROS `header.stamp` field instead of `timestamp_us`.
 
 ## Control Protocol
 

--- a/bridge/python/hand_zenoh_bridge.py
+++ b/bridge/python/hand_zenoh_bridge.py
@@ -72,6 +72,29 @@ def sanitize_sn(sn: str) -> str:
     return sn.replace(".", "_")
 
 
+# ---------------------------------------------------------------------------
+# Joint naming (matches wuji-hand-description URDF)
+# ---------------------------------------------------------------------------
+
+# Resources that stream raw values without the {timestamp_us, data} envelope.
+# These typically expose ROS-compatible schemas (e.g. sensor_msgs/JointState)
+# so downstream viewers like Wuji Studio can identify them by schema name.
+_ENVELOPE_EXEMPT_PATHS = frozenset({"joint_states"})
+
+
+def make_joint_names(side: str) -> list:
+    """Build 20 joint names matching `wuji-hand-description/urdf/{side}.urdf`.
+
+    Row-major flatten order of the 5x4 joint array:
+        name[i * 4 + j] = f"{side}_finger{i+1}_joint{j+1}"
+    """
+    return [
+        f"{side}_finger{finger + 1}_joint{joint + 1}"
+        for finger in range(5)
+        for joint in range(4)
+    ]
+
+
 # Resource definitions
 RESOURCE_DEFS = [
     # GET-only scalar resources
@@ -204,12 +227,44 @@ RESOURCE_DEFS = [
     },
     {
         "path": "joint/target_position",
-        "can_get": False, "can_set": True, "can_sub": False,
+        "can_get": False, "can_set": True, "can_sub": False, "can_pub": True,
         "json_schema": {
             "title": "JointTargetPosition",
             "type": "array",
             "description": "5x4 joint target positions",
             "items": {"type": "array", "items": {"type": "number"}},
+        },
+    },
+    # Title must stay exactly "sensor_msgs/JointState" — Studio's 3D panel
+    # keys on the schema title, so this path opts out of the timestamp
+    # envelope (see _ENVELOPE_EXEMPT_PATHS) and carries ordering in the
+    # standard ROS `header.stamp` instead.
+    {
+        "path": "joint_states",
+        "can_get": False, "can_set": False, "can_sub": True,
+        "json_schema": {
+            "title": "sensor_msgs/JointState",
+            "type": "object",
+            "properties": {
+                "header": {
+                    "type": "object",
+                    "properties": {
+                        "stamp": {
+                            "type": "object",
+                            "properties": {
+                                "sec":  {"type": "integer"},
+                                "nsec": {"type": "integer"},
+                            },
+                            "required": ["sec", "nsec"],
+                        },
+                        "frame_id": {"type": "string"},
+                    },
+                    "required": ["stamp", "frame_id"],
+                },
+                "name": {"type": "array", "items": {"type": "string"}},
+                "position": {"type": "array", "items": {"type": "number"}},
+            },
+            "required": ["header", "name", "position"],
         },
     },
 ]
@@ -225,16 +280,20 @@ def build_capability(serial_number: str) -> str:
             "can_get": r["can_get"],
             "can_set": r["can_set"],
             "can_sub": r["can_sub"],
-            "can_pub": False,
+            "can_pub": r.get("can_pub", False),
             "can_exec": False,
             "internal": False,
             "serde_format": "json",
             "json_schema": r["json_schema"],
         })
 
-    # Wrap SUB resource schemas with timestamp envelope
+    # Wrap SUB resource schemas with timestamp envelope (except exempt paths)
     for res in resources:
-        if res["can_sub"] and res.get("json_schema"):
+        if (
+            res["can_sub"]
+            and res.get("json_schema")
+            and res["path"] not in _ENVELOPE_EXEMPT_PATHS
+        ):
             original_schema = res["json_schema"]
             res["json_schema"] = {
                 "title": original_schema.get("title", "") + "Timestamped",
@@ -265,23 +324,51 @@ class HandBridge:
     LowPass interpolation) instead of SDO for smooth motion control.
     """
 
-    def __init__(self, hand, serial_number: str, pub_rate: float):
+    def __init__(
+        self,
+        hand,
+        serial_number: str,
+        pub_rate: float,
+        side: str = "left",
+        filter_cutoff_hz: float = 5.0,
+    ):
         """Initialize the Hand Zenoh Bridge.
 
         Args:
             hand: A wujihandpy.Hand instance (USB-connected).
             serial_number: Device serial number for Zenoh key registration.
             pub_rate: SUB resource publish rate in Hz (e.g. 1000). Must be positive.
+            side: Which hand's joint names to publish for `joint_states`
+                  ("left" or "right"). Must match the URDF side loaded in Studio.
+                  Defaults to "left" for programmatic / unit-test callers; the
+                  CLI entry point (`main`) requires it explicitly via `--side`.
+            filter_cutoff_hz: LowPass cutoff frequency applied by the internal
+                  realtime_controller to smooth target_position writes. The
+                  filter runs at PDO rate (1 kHz) and bridges the gap between
+                  the bridge's 100 Hz feed loop and the motor's 1 kHz update
+                  rate — lower = smoother / slower response, higher =
+                  snappier / noisier. Defaults to 5 Hz, matching
+                  `wujihandpy/example/3.realtime.py`. Must be positive.
 
         Raises:
-            ValueError: If pub_rate is not positive.
+            ValueError: If pub_rate is not positive, side is not 'left'/'right',
+                or filter_cutoff_hz is not positive.
         """
         if pub_rate <= 0:
             raise ValueError(f"pub_rate must be positive, got {pub_rate}")
+        if side not in ("left", "right"):
+            raise ValueError(f"side must be 'left' or 'right', got {side!r}")
+        if filter_cutoff_hz <= 0:
+            raise ValueError(
+                f"filter_cutoff_hz must be positive, got {filter_cutoff_hz}"
+            )
         self.hand = hand
         self.sn = serial_number
         self.sanitized_sn = sanitize_sn(serial_number)
         self.pub_rate = pub_rate
+        self._side = side
+        self._joint_names = make_joint_names(side)
+        self._filter_cutoff_hz = filter_cutoff_hz
         self.session = None
         self._alive_token = None
         self._running = False
@@ -293,6 +380,11 @@ class HandBridge:
         self._publishers = {}
         self._hand_lock = threading.Lock()
         self._control_lock = threading.Lock()
+        # Strictly-monotonic ns timestamp for `header.stamp` on joint_states.
+        # Uses CLOCK_MONOTONIC (time.monotonic_ns) so NTP / wall-clock jumps
+        # can't cause regressions, plus a +1 floor against same-value reads.
+        self._stamp_lock = threading.Lock()
+        self._last_stamp_ns = 0
         # Realtime controller state
         self._controller = None
         self._rt_target = np.zeros((5, 4), dtype=np.float64)
@@ -303,6 +395,20 @@ class HandBridge:
     def _key(self, suffix: str) -> str:
         """Build a Zenoh key expression: wuji/{sanitized_sn}/{suffix}."""
         return f"wuji/{self.sanitized_sn}/{suffix}"
+
+    def _next_stamp_ns(self) -> int:
+        """Strictly-monotonic nanosecond stamp for `header.stamp`.
+
+        time.monotonic_ns() is CLOCK_MONOTONIC (immune to wall-clock jumps /
+        NTP slewing), but adjacent calls can return the same value on
+        low-resolution timers. The +1 floor guarantees strict `>`.
+        """
+        with self._stamp_lock:
+            now = time.monotonic_ns()
+            if now <= self._last_stamp_ns:
+                now = self._last_stamp_ns + 1
+            self._last_stamp_ns = now
+            return now
 
     def _control_owner_key(self, owner_zid: str) -> str:
         """Liveliness key for tracking a control owner's presence."""
@@ -390,12 +496,19 @@ class HandBridge:
         with self._rt_lock:
             self._rt_target = initial_pos.copy()
 
-        # Use an extremely high cutoff so the filter is effectively a passthrough.
-        # realtime_controller() requires an IFilter; there is no identity filter.
-        logger.info("Starting realtime controller (no filtering, upstream enabled)...")
+        # LowPass filter runs at PDO rate (1 kHz) inside the realtime controller,
+        # smoothing the 100 Hz feed loop's step-changes out to 1 ms granularity
+        # before they reach the motor. Cutoff is configurable via `--filter-cutoff`
+        # (default 5 Hz, matching wujihandpy/example/3.realtime.py). A very high
+        # cutoff (e.g. 10000 Hz) approximates a passthrough if callers prefer to
+        # supply pre-filtered targets.
+        logger.info(
+            "Starting realtime controller (lowpass cutoff=%.1f Hz, upstream enabled)...",
+            self._filter_cutoff_hz,
+        )
         self._controller = self.hand.realtime_controller(
             enable_upstream=True,
-            filter=wujihandpy.filter.LowPass(cutoff_freq=10000.0),
+            filter=wujihandpy.filter.LowPass(cutoff_freq=self._filter_cutoff_hz),
         )
         self._controller.__enter__()
 
@@ -700,6 +813,19 @@ class HandBridge:
         except Exception as e:
             logger.error(f"target_position subscriber error: {e}")
 
+    def _read_joint_actual_position(self):
+        """Fetch the 5x4 actual-position array from the best available source.
+
+        Prefers the realtime controller's zero-copy cache; falls back to SDO
+        under hand_lock. Shared by `joint/actual_position` and `joint_states`
+        so both reflect the same underlying sample.
+        """
+        controller = self._controller
+        if controller is not None:
+            return controller.get_joint_actual_position()
+        with self._hand_lock:
+            return self.hand.read_joint_actual_position()
+
     def _read_resource(self, path: str):
         """Read a resource from the hand, return JSON-serializable value.
 
@@ -708,9 +834,8 @@ class HandBridge:
         """
         controller = self._controller
 
-        if path == "joint/actual_position" and controller is not None:
-            # Zero-copy from controller cache, no SDO needed
-            return controller.get_joint_actual_position().tolist()
+        if path == "joint/actual_position":
+            return self._read_joint_actual_position().tolist()
 
         if path == "joint/actual_effort":
             if controller is not None:
@@ -718,6 +843,18 @@ class HandBridge:
             # actual_effort is only exposed from the realtime controller cache;
             # during shutdown races, return a zeroed snapshot instead of failing.
             return np.zeros((5, 4), dtype=np.float64).tolist()
+
+        if path == "joint_states":
+            pos = self._read_joint_actual_position()
+            ns = self._next_stamp_ns()
+            return {
+                "header": {
+                    "stamp": {"sec": ns // 1_000_000_000, "nsec": ns % 1_000_000_000},
+                    "frame_id": f"{self._side}_palm_link",
+                },
+                "name": self._joint_names,
+                "position": pos.flatten().tolist(),
+            }
 
         # All other reads need SDO access via hand_lock
         with self._hand_lock:
@@ -729,8 +866,6 @@ class HandBridge:
                 return int(self.hand.read_handedness())
             elif path == "firmware_version":
                 return int(self.hand.read_firmware_version())
-            elif path == "joint/actual_position":
-                return self.hand.read_joint_actual_position().tolist()
             elif path == "joint/temperature":
                 return self.hand.read_joint_temperature().tolist()
             elif path == "joint/error_code":
@@ -779,8 +914,13 @@ class HandBridge:
     def _publish_loop(self):
         """Continuously publish SUB resources at configured rate.
 
-        Each published message is wrapped with a host-side timestamp:
+        Most messages are wrapped with a host-side timestamp:
             {"timestamp_us": <UTC microseconds>, "data": <value>}
+
+        Paths listed in `_ENVELOPE_EXEMPT_PATHS` are published as-is, so their
+        schema title (advertised in @capability) matches the declared type
+        (e.g. `sensor_msgs/JointState`) and downstream consumers can identify
+        them without unwrapping.
         """
         period = 1.0 / self.pub_rate
         while self._running:
@@ -788,8 +928,11 @@ class HandBridge:
                 timestamp_us = get_timestamp_us()
                 for path, pub in self._publishers.items():
                     value = self._read_resource(path)
-                    envelope = wrap_with_timestamp(value, timestamp_us)
-                    data = json.dumps(envelope).encode("utf-8")
+                    if path in _ENVELOPE_EXEMPT_PATHS:
+                        payload = value
+                    else:
+                        payload = wrap_with_timestamp(value, timestamp_us)
+                    data = json.dumps(payload).encode("utf-8")
                     pub.put(data)
             except Exception as e:
                 logger.error(f"Publish loop error: {e}")
@@ -801,6 +944,29 @@ def main():
     parser = argparse.ArgumentParser(description="Wuji Hand Zenoh Bridge")
     parser.add_argument("--sn", type=str, default=None, help="Hand serial number filter")
     parser.add_argument("--pub-rate", type=float, required=True, help="Position publish rate in Hz (e.g. 1000)")
+    parser.add_argument(
+        "--side",
+        type=str,
+        required=True,
+        choices=("left", "right"),
+        help=(
+            "Which hand this bridge represents. Drives the joint names published "
+            "on `joint_states` (e.g. left_finger1_joint1). Must match the URDF "
+            "loaded in Wuji Studio."
+        ),
+    )
+    parser.add_argument(
+        "--filter-cutoff",
+        type=float,
+        default=5.0,
+        help=(
+            "LowPass cutoff (Hz) for the internal realtime_controller. Smooths "
+            "target_position writes at PDO 1 kHz. Lower = smoother / slower, "
+            "higher = snappier / noisier. Set very high (e.g. 10000) to "
+            "approximate passthrough if you pre-filter targets client-side. "
+            "Default: 5.0 (matches wujihandpy/example/3.realtime.py)."
+        ),
+    )
     parser.add_argument("--log-level", type=str, default="INFO", help="Log level")
     args = parser.parse_args()
 
@@ -821,7 +987,13 @@ def main():
         logger.warning(f"Could not read product SN (firmware too old?), using: {sn}")
     logger.info(f"Hand connected, SN: {sn}")
 
-    bridge = HandBridge(hand, serial_number=sn, pub_rate=args.pub_rate)
+    bridge = HandBridge(
+        hand,
+        serial_number=sn,
+        pub_rate=args.pub_rate,
+        side=args.side,
+        filter_cutoff_hz=args.filter_cutoff,
+    )
     try:
         bridge.start()
         logger.info("Bridge running. Press Ctrl+C to stop.")

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -19,6 +19,7 @@ from bridge.python.hand_zenoh_bridge import (
     wrap_with_timestamp,
     HandBridge,
     RESOURCE_DEFS,
+    make_joint_names,
 )
 
 
@@ -202,6 +203,67 @@ def test_resource_defs_count():
     paths = [resource["path"] for resource in RESOURCE_DEFS]
     assert len(RESOURCE_DEFS) >= 10
     assert len(paths) == len(set(paths))
+
+
+# ---------------------------------------------------------------------------
+# joint_states (ROS-compatible URDF-driving stream)
+# ---------------------------------------------------------------------------
+
+def test_make_joint_names_left_layout():
+    names = make_joint_names("left")
+    assert len(names) == 20
+    # Row-major 5x4 flattening: finger1..5, joint1..4
+    assert names[0] == "left_finger1_joint1"
+    assert names[3] == "left_finger1_joint4"
+    assert names[4] == "left_finger2_joint1"
+    assert names[19] == "left_finger5_joint4"
+
+
+def test_make_joint_names_right_prefix():
+    names = make_joint_names("right")
+    assert all(n.startswith("right_finger") for n in names)
+
+
+def test_joint_states_capability_schema_not_wrapped():
+    # joint_states must keep schema title "sensor_msgs/JointState" exactly so
+    # Wuji Studio's 3D panel (which identifies JointState by schema title) can
+    # recognize and subscribe to it.
+    cap = json.loads(build_capability("TEST"))
+    by_path = {r["path"]: r for r in cap["resources"]}
+
+    js = by_path["joint_states"]
+    assert js["can_sub"] is True
+    assert js["can_get"] is False
+    assert js["json_schema"]["title"] == "sensor_msgs/JointState"
+    assert js["json_schema"]["type"] == "object"
+    assert set(js["json_schema"]["properties"].keys()) == {"header", "name", "position"}
+    # Studio's URDF handler relies on header.stamp for ordering.
+    stamp_props = js["json_schema"]["properties"]["header"]["properties"]["stamp"]["properties"]
+    assert set(stamp_props.keys()) == {"sec", "nsec"}
+    # Envelope wrap would add a 'timestamp_us' property; make sure it did NOT.
+    assert "timestamp_us" not in js["json_schema"]["properties"]
+
+
+def test_read_resource_joint_states_flatten_row_major():
+    hand = MagicMock()
+    positions = np.arange(20, dtype=np.float64).reshape(5, 4)
+    hand.read_joint_actual_position.return_value = positions
+
+    bridge = HandBridge(hand, "TEST", pub_rate=100.0, side="left")
+    # No realtime controller → falls back to hand.read_joint_actual_position()
+    result = bridge._read_resource("joint_states")
+
+    assert result["name"] == make_joint_names("left")
+    assert result["position"] == list(range(20))  # 0..19 in row-major order
+    # Index must align with joint name
+    assert result["name"][5] == "left_finger2_joint2"
+    assert result["position"][5] == 5.0
+
+
+def test_bridge_rejects_invalid_side():
+    hand = MagicMock()
+    with pytest.raises(ValueError, match="side"):
+        HandBridge(hand, "TEST", pub_rate=100.0, side="middle")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add a ROS-compatible `joint_states` SUB topic (`sensor_msgs/JointState`) so Wuji Studio's 3D panel can drive a URDF visualization off the bridge without touching the control path. Envelope-exempt so the schema title stays `sensor_msgs/JointState` exactly; ordering carried in `header.stamp` via a bridge-side monotonic clock.
- Make the `realtime_controller` LowPass cutoff configurable via `--filter-cutoff` (default 5 Hz, matching `example/3.realtime.py`); previously hard-coded at 10000 Hz (effectively passthrough).
- Require `--side {left,right}` at launch so the 20 published joint names match the URDF loaded downstream (`{side}_finger{1..5}_joint{1..4}`, per `wuji-hand-description`).

## Test plan

- [x] `pytest tests/test_bridge.py` — 47/47 pass (includes 4 new tests covering joint name layout, envelope-exempt capability schema, row-major flatten, and `--side` validation).
- [ ] Launch bridge with `--side left --pub-rate 1000`, open Wuji Studio 3D panel with `left.urdf`, verify URDF animates from live device.
- [ ] Run a concurrent control client (e.g. Rust `wujihand_zenoh_control` sine sweep) alongside Studio to confirm visualization and control paths are independent.
- [ ] Sanity-check `--filter-cutoff 10000` restores prior near-passthrough behavior.

Resolve swd-1032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加必需参数 `--side`（left/right）和可选 `--filter-cutoff`（默认 5.0 Hz），用于侧别命名与低通滤波行为调整
  * 新增 ROS 兼容的 joint_states 订阅流，按 side 生成 joint 名称并以 sensor_msgs/JointState 格式发布（不带外层时间信封，使用桥端单调 header.stamp 保证顺序）

* **文档**
  * 更新启动示例、数据格式与资源说明，新增在 Wuji Studio 中基于 side 自动订阅 joint_states 的可视化指南
<!-- end of auto-generated comment: release notes by coderabbit.ai -->