### PR TITLE
feat(bridge): drop @control acquire/release protocol [SWD-1132]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **Zenoh Bridge (Python + C++)**: removed `@control` acquire/release protocol
+  and the liveliness-based owner TTL watcher. Writes (SET resources,
+  fire-and-forget `joint/target_position` PUT) no longer require an acquire
+  handshake or a requester-identity attachment — any client reachable over
+  Zenoh may write. Single-writer protection, if needed, must be enforced by
+  the deployment topology (firewall rules, Zenoh ACL, isolated network).
+
+  Aligns with `wuji-sdk` PR #215 [SWD-1132], which removed the corresponding
+  `acquire_control` / `release_control` SDK API and per-write attachment
+  plumbing. Without this companion change, `wuji-sdk` clients would lose
+  the ability to write WujiHand via this bridge.
+
+  Removed (Python): `_handle_control` / `_get_requester_id` /
+  `_start_owner_watcher` / `_stop_owner_watcher` / `_control_owner_key` /
+  `_control_owner` / `_control_lock` / `_control_owner_watcher` /
+  `decode_zenoh_text` (now unused).
+  Removed (C++): `handle_control` / `start_owner_watcher` /
+  `stop_owner_watcher` / `control_owner_key` / `control_owner_` /
+  `control_mutex_` / `control_owner_watcher_` / `requester_id_from_attachment`.
+  Tests: 14 control-권 / attachment / owner-watcher unit tests removed,
+  replaced with one positive test confirming SET succeeds without an
+  attachment. README "Control Protocol" section replaced with a "Write
+  Access" note explaining the new policy.
+
 ## [1.6.0] - 2026-04-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,29 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- **Zenoh Bridge (Python + C++)**: removed `@control` acquire/release protocol
-  and the liveliness-based owner TTL watcher. Writes (SET resources,
-  fire-and-forget `joint/target_position` PUT) no longer require an acquire
-  handshake or a requester-identity attachment — any client reachable over
-  Zenoh may write. Single-writer protection, if needed, must be enforced by
-  the deployment topology (firewall rules, Zenoh ACL, isolated network).
-
-  Aligns with `wuji-sdk` PR #215 [SWD-1132], which removed the corresponding
-  `acquire_control` / `release_control` SDK API and per-write attachment
-  plumbing. Without this companion change, `wuji-sdk` clients would lose
-  the ability to write WujiHand via this bridge.
-
-  Removed (Python): `_handle_control` / `_get_requester_id` /
-  `_start_owner_watcher` / `_stop_owner_watcher` / `_control_owner_key` /
-  `_control_owner` / `_control_lock` / `_control_owner_watcher` /
-  `decode_zenoh_text` (now unused).
-  Removed (C++): `handle_control` / `start_owner_watcher` /
-  `stop_owner_watcher` / `control_owner_key` / `control_owner_` /
-  `control_mutex_` / `control_owner_watcher_` / `requester_id_from_attachment`.
-  Tests: 14 control-권 / attachment / owner-watcher unit tests removed,
-  replaced with one positive test confirming SET succeeds without an
-  attachment. README "Control Protocol" section replaced with a "Write
-  Access" note explaining the new policy.
+- **Zenoh Bridge (Python + C++)**: removed `@control` acquire/release protocol; SET / PUT writes no longer require an acquire handshake.
 
 ## [1.6.0] - 2026-04-27
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -80,10 +80,8 @@ def callback(sample):
 
 
 session = zenoh.open(zenoh.Config())
-zid = str(session.zid())
 target = [[0.1, 0.0, 0.1, 0.1] for _ in range(5)]
 sub = None
-owner_token = session.liveliness().declare_token(f"wuji/{sn}/@control_owner/{zid}")
 
 try:
     # 1. Discover devices via liveliness
@@ -92,34 +90,18 @@ try:
     # 2. Query capability
     replies = session.get(f"wuji/{sn}/@capability", timeout=5.0)
 
-    # 3. Acquire control (declare the control-owner liveliness token first)
-    session.get(
-        f"wuji/{sn}/@control",
-        payload=f"acquire:{zid}".encode(),
-        attachment=zid.encode(),
-        timeout=5.0,
-    )
-
-    # 4. Read data (GET)
+    # 3. Read data (GET)
     replies = session.get(f"wuji/{sn}/joint/actual_position", timeout=5.0)
 
-    # 5. Write target position (low-latency fire-and-forget PUT)
+    # 4. Write target position (low-latency fire-and-forget PUT)
     session.put(
         f"wuji/{sn}/joint/target_position",
         json.dumps(target).encode(),
-        attachment=zid.encode(),
     )
 
-    # 6. Subscribe to realtime data (rate controlled by --pub-rate)
+    # 5. Subscribe to realtime data (rate controlled by --pub-rate)
     sub = session.declare_subscriber(f"wuji/{sn}/joint/actual_position", callback)
 finally:
-    session.get(
-        f"wuji/{sn}/@control",
-        payload=f"release:{zid}".encode(),
-        attachment=zid.encode(),
-        timeout=5.0,
-    )
-    owner_token.undeclare()
     if sub is not None:
         sub.undeclare()
     session.close()
@@ -152,8 +134,6 @@ finally:
 
 ### SET Resources
 
-These resources require control ownership.
-
 | Path | Type | Description |
 |------|------|-------------|
 | `joint/target_position` | 5x4 float | Target position |
@@ -179,16 +159,9 @@ By default, SUB resources are published as a timestamped envelope:
 
 **Exception:** `joint_states` is published raw (no envelope) so its schema title remains exactly `sensor_msgs/JointState` for downstream consumers that key on schema name (e.g. Wuji Studio's 3D panel). Ordering for this topic is carried in the standard ROS `header.stamp` field instead of `timestamp_us`.
 
-## Control Protocol
+## Write Access
 
-- Acquire: send `acquire:{your_zid}` and receive `granted` or `denied:{current_owner}`
-- Release: send `release:{your_zid}` and receive `released`
-- Query: send an empty payload and receive the current owner or `none`
-- Auto-release on crash: the bridge watches the owner's Zenoh liveliness token and releases control if that process disappears
-
-Control-changing requests must attach the requester identity in the Zenoh attachment. The bridge verifies that:
-- `@control` acquire/release uses the same requester in both payload and attachment
-- fire-and-forget `joint/target_position` PUT uses the current control owner's requester id in the attachment
+Writes (SET resources, fire-and-forget `joint/target_position` PUT) are **not gated by an `@control` acquire/release handshake**. Any client that can reach the bridge over Zenoh may write. Single-writer protection, if needed, must be enforced by the deployment topology (e.g. firewall rules, Zenoh ACL, or running the bridge on an isolated network).
 
 ## Visualize in Wuji Studio
 

--- a/bridge/cpp/src/hand_bridge.cpp
+++ b/bridge/cpp/src/hand_bridge.cpp
@@ -48,25 +48,10 @@ static void log_info(const std::string& msg) {
     logging::log(logging::Level::INFO, msg.c_str(), msg.size());
 }
 
-static void log_warn(const std::string& msg) {
-    logging::log(logging::Level::WARN, msg.c_str(), msg.size());
-}
-
 static void log_error(const std::string& msg) {
     logging::log(logging::Level::ERR, msg.c_str(), msg.size());
 }
 
-static std::optional<std::string> requester_id_from_attachment(
-    const std::optional<std::reference_wrapper<const zenoh::Bytes>>& attachment) {
-    if (!attachment.has_value()) {
-        return std::nullopt;
-    }
-    auto requester = attachment->get().as_string();
-    if (requester.empty()) {
-        return std::nullopt;
-    }
-    return requester;
-}
 
 // ---------------------------------------------------------------------------
 // Resource definitions (must match Python bridge exactly)
@@ -254,16 +239,7 @@ void HandBridge::start() {
         []() {}));
     log_info("@capability queryable declared");
 
-    // 5. Control queryable
-    queryables_.push_back(session_->declare_queryable(
-        zenoh::KeyExpr(key("@control")),
-        [this](zenoh::Query& query) {
-            handle_control(query);
-        },
-        []() {}));
-    log_info("@control queryable declared");
-
-    // 6. Resource queryables + publishers for SUB resources
+    // 5. Resource queryables + publishers for SUB resources
     for (const auto& r : resource_defs()) {
         if (r.can_get || r.can_set) {
             auto r_copy = r;  // capture by value to avoid dangling reference
@@ -282,29 +258,14 @@ void HandBridge::start() {
         }
     }
 
-    // 7. Subscribe to target_position for fire-and-forget writes (low latency)
+    // 6. Subscribe to target_position for fire-and-forget writes (low latency).
+    //    Note: writes are no longer gated by an `@control` acquire/release
+    //    handshake — single-writer protection, if needed, must be enforced by
+    //    the deployment topology (e.g. firewall rules, Zenoh access control).
     subscribers_.push_back(session_->declare_subscriber(
         zenoh::KeyExpr(key("joint/target_position")),
         [this](zenoh::Sample& sample) {
             try {
-                auto requester = requester_id_from_attachment(sample.get_attachment());
-                {
-                    std::lock_guard lock(control_mutex_);
-                    if (control_owner_.empty()) {
-                        log_warn("Ignoring target_position PUT without control owner");
-                        return;
-                    }
-                    if (!requester.has_value()) {
-                        log_warn("Ignoring target_position PUT without requester attachment");
-                        return;
-                    }
-                    if (*requester != control_owner_) {
-                        log_warn(
-                            "Ignoring target_position PUT from non-owner requester " + *requester + " (owner=" +
-                            control_owner_ + ")");
-                        return;
-                    }
-                }
                 auto value = json::parse(sample.get_payload().as_string());
                 write_resource("joint/target_position", value);
             } catch (const std::exception& e) {
@@ -314,7 +275,7 @@ void HandBridge::start() {
         []() {}));
     log_info("target_position subscriber declared (fire-and-forget path)");
 
-    // 8. Start publisher jthread
+    // 7. Start publisher jthread
     if (!publishers_.empty()) {
         pub_thread_ = std::jthread([this](std::stop_token st) {
             publish_loop(std::move(st));
@@ -347,7 +308,6 @@ void HandBridge::stop() {
     }
 
     // 4. Clear Zenoh resources (RAII)
-    stop_owner_watcher();
     subscribers_.clear();
     queryables_.clear();
     publishers_.clear();
@@ -396,139 +356,6 @@ void HandBridge::stop_realtime_controller() {
 }
 
 // ---------------------------------------------------------------------------
-// Liveliness-based control TTL
-// ---------------------------------------------------------------------------
-std::string HandBridge::control_owner_key(const std::string& owner_zid) const {
-    return key("@control_owner/" + owner_zid);
-}
-
-void HandBridge::start_owner_watcher(const std::string& owner_zid) {
-    stop_owner_watcher();
-
-    auto owner_key = control_owner_key(owner_zid);
-    control_owner_watcher_.emplace(session_->liveliness_declare_subscriber(
-        zenoh::KeyExpr(owner_key),
-        [this, owner_zid](zenoh::Sample& sample) {
-            // SampleKind::Z_SAMPLE_KIND_DELETE means liveliness token dropped (owner crashed)
-            if (sample.get_kind() == Z_SAMPLE_KIND_DELETE) {
-                {
-                    std::lock_guard lock(control_mutex_);
-                    if (control_owner_ == owner_zid) {
-                        log_info("Control owner " + owner_zid + " crashed, auto-releasing");
-                        control_owner_.clear();
-                    }
-                }
-                // Keep the watcher alive until explicit release, replacement, or shutdown.
-                // Resetting the subscriber from inside its own callback is unsafe.
-            }
-        },
-        []() {}));
-    log_info("Owner watcher started for " + owner_zid);
-}
-
-void HandBridge::stop_owner_watcher() {
-    control_owner_watcher_.reset();
-}
-
-// ---------------------------------------------------------------------------
-// handle_control
-// ---------------------------------------------------------------------------
-void HandBridge::handle_control(zenoh::Query& query) {
-    auto key_str = key("@control");
-
-    std::string payload_str;
-    auto payload_opt = query.get_payload();
-    if (payload_opt.has_value()) {
-        payload_str = payload_opt->get().as_string();
-    }
-    auto attachment_requester = requester_id_from_attachment(query.get_attachment());
-
-    if (payload_str.starts_with("acquire:")) {
-        auto requester = payload_str.substr(8);
-        if (!attachment_requester.has_value() || *attachment_requester != requester) {
-            query.reply_err(zenoh::Bytes("identity_mismatch"));
-            log_warn(
-                "Control acquire rejected: payload requester " + requester + " != attachment requester " +
-                attachment_requester.value_or("<missing>"));
-            return;
-        }
-
-        std::string current_owner;
-        {
-            std::lock_guard lock(control_mutex_);
-            current_owner = control_owner_;
-            if (!current_owner.empty() && current_owner != requester) {
-                // handled after releasing the mutex
-            } else {
-                control_owner_ = requester;
-                current_owner.clear();
-            }
-        }
-        if (!current_owner.empty()) {
-            query.reply(zenoh::KeyExpr(key_str),
-                        zenoh::Bytes("denied:" + current_owner));
-            log_info("Control denied to " + requester + ", owner: " + current_owner);
-            return;
-        }
-
-        try {
-            start_owner_watcher(requester);
-            {
-                std::lock_guard lock(control_mutex_);
-                if (control_owner_ != requester) {
-                    throw std::runtime_error("control owner lost before acquire completed");
-                }
-            }
-            query.reply(zenoh::KeyExpr(key_str),
-                        zenoh::Bytes("granted"));
-            log_info("Control granted to " + requester);
-        } catch (const std::exception& e) {
-            {
-                std::lock_guard lock(control_mutex_);
-                if (control_owner_ == requester) {
-                    control_owner_.clear();
-                }
-            }
-            stop_owner_watcher();
-            query.reply_err(zenoh::Bytes(std::string(e.what())));
-            log_error("Control acquire failed for " + requester + ": " + e.what());
-        }
-    } else if (payload_str.starts_with("release:")) {
-        auto requester = payload_str.substr(8);
-        if (!attachment_requester.has_value() || *attachment_requester != requester) {
-            query.reply_err(zenoh::Bytes("identity_mismatch"));
-            log_warn(
-                "Control release rejected: payload requester " + requester + " != attachment requester " +
-                attachment_requester.value_or("<missing>"));
-            return;
-        }
-
-        bool released = false;
-        {
-            std::lock_guard lock(control_mutex_);
-            if (control_owner_ == requester) {
-                control_owner_.clear();
-                released = true;
-            }
-        }
-        if (released) {
-            stop_owner_watcher();
-            query.reply(zenoh::KeyExpr(key_str),
-                        zenoh::Bytes("released"));
-            log_info("Control released by " + requester);
-        } else {
-            query.reply(zenoh::KeyExpr(key_str),
-                        zenoh::Bytes("not_owner"));
-        }
-    } else {
-        std::lock_guard lock(control_mutex_);
-        auto owner = control_owner_.empty() ? std::string("none") : control_owner_;
-        query.reply(zenoh::KeyExpr(key_str),
-                    zenoh::Bytes(owner));
-    }
-}
-
-// ---------------------------------------------------------------------------
 // handle_resource_query
 // ---------------------------------------------------------------------------
 void HandBridge::handle_resource_query(zenoh::Query& query, const ResourceDef& res) {
@@ -561,25 +388,6 @@ void HandBridge::handle_resource_query(zenoh::Query& query, const ResourceDef& r
         if (!res.can_set) {
             query.reply_err(zenoh::Bytes("SET not supported"));
             return;
-        }
-        auto requester = requester_id_from_attachment(query.get_attachment());
-        {
-            std::lock_guard lock(control_mutex_);
-            if (control_owner_.empty()) {
-                query.reply_err(zenoh::Bytes("no control owner"));
-                return;
-            }
-            if (!requester.has_value()) {
-                query.reply_err(zenoh::Bytes("missing requester id"));
-                log_warn("SET " + res.path + " rejected: missing requester attachment");
-                return;
-            }
-            if (*requester != control_owner_) {
-                query.reply_err(zenoh::Bytes("not control owner"));
-                log_warn(
-                    "SET " + res.path + " rejected: requester " + *requester + " != owner " + control_owner_);
-                return;
-            }
         }
         try {
             auto value = json::parse(payload_str);

--- a/bridge/cpp/src/hand_bridge.hpp
+++ b/bridge/cpp/src/hand_bridge.hpp
@@ -53,9 +53,6 @@ private:
     // Resource definitions
     static const std::vector<ResourceDef>& resource_defs();
 
-    // Control protocol handler
-    void handle_control(zenoh::Query& query);
-
     // Resource queryable handler
     void handle_resource_query(zenoh::Query& query, const ResourceDef& res);
 
@@ -92,14 +89,6 @@ private:
 
     // Thread safety
     std::mutex hand_mutex_;    // Protects SDO read/write operations
-    std::mutex control_mutex_; // Protects control_owner_
-    std::string control_owner_;
-
-    // Liveliness-based control TTL
-    std::optional<zenoh::Subscriber<void>> control_owner_watcher_;
-    void start_owner_watcher(const std::string& owner_zid);
-    void stop_owner_watcher();
-    std::string control_owner_key(const std::string& owner_zid) const;
 
     // Publisher thread
     std::jthread pub_thread_;

--- a/bridge/python/hand_zenoh_bridge.py
+++ b/bridge/python/hand_zenoh_bridge.py
@@ -38,32 +38,6 @@ def wrap_with_timestamp(value, timestamp_us: Optional[int] = None) -> dict:
     return {"timestamp_us": timestamp_us, "data": value}
 
 
-def decode_zenoh_text(value) -> Optional[str]:
-    """Best-effort decode for Zenoh payload/attachment text fields."""
-    if value is None:
-        return None
-    if isinstance(value, str):
-        return value
-    if isinstance(value, (bytes, bytearray)):
-        return bytes(value).decode("utf-8", errors="replace")
-
-    to_string = getattr(value, "to_string", None)
-    if callable(to_string):
-        decoded = to_string()
-        if isinstance(decoded, str):
-            return decoded
-
-    to_bytes = getattr(value, "to_bytes", None)
-    if callable(to_bytes):
-        decoded = to_bytes()
-        if isinstance(decoded, (bytes, bytearray)):
-            return bytes(decoded).decode("utf-8", errors="replace")
-
-    try:
-        return bytes(value).decode("utf-8", errors="replace")
-    except (TypeError, ValueError):
-        return None
-
 logger = logging.getLogger("hand_bridge")
 
 
@@ -372,14 +346,11 @@ class HandBridge:
         self.session = None
         self._alive_token = None
         self._running = False
-        self._control_owner = None
-        self._control_owner_watcher = None  # liveliness subscriber for owner TTL
         self._threads = []
         self._queryables = []
         self._subscribers = []
         self._publishers = {}
         self._hand_lock = threading.Lock()
-        self._control_lock = threading.Lock()
         # Strictly-monotonic ns timestamp for `header.stamp` on joint_states.
         # Uses CLOCK_MONOTONIC (time.monotonic_ns) so NTP / wall-clock jumps
         # can't cause regressions, plus a +1 floor against same-value reads.
@@ -410,45 +381,6 @@ class HandBridge:
             self._last_stamp_ns = now
             return now
 
-    def _control_owner_key(self, owner_zid: str) -> str:
-        """Liveliness key for tracking a control owner's presence."""
-        return f"wuji/{self.sanitized_sn}/@control_owner/{owner_zid}"
-
-    def _start_owner_watcher(self, owner_zid: str):
-        """Start watching owner's liveliness. Auto-release control if owner crashes."""
-        self._stop_owner_watcher()
-
-        owner_key = self._control_owner_key(owner_zid)
-
-        def on_sample(sample):
-            """Handle liveliness change; auto-release control on owner crash."""
-            # SampleKind.DELETE means the liveliness token was dropped (owner crashed)
-            if hasattr(sample, "kind") and sample.kind == zenoh.SampleKind.DELETE:
-                with self._control_lock:
-                    if self._control_owner == owner_zid:
-                        logger.warning(f"Control owner {owner_zid} crashed, auto-releasing")
-                        self._control_owner = None
-                self._stop_owner_watcher()
-
-        try:
-            watcher = self.session.liveliness().declare_subscriber(owner_key, on_sample)
-            if watcher is None:
-                raise RuntimeError(f"declare_subscriber returned None for {owner_key}")
-            self._control_owner_watcher = watcher
-            logger.debug(f"Owner watcher started for {owner_zid}")
-        except Exception:
-            self._control_owner_watcher = None
-            raise
-
-    def _stop_owner_watcher(self):
-        """Stop watching the current owner's liveliness."""
-        if self._control_owner_watcher is not None:
-            try:
-                self._control_owner_watcher.undeclare()
-            except Exception as e:
-                logger.debug(f"Failed to undeclare owner watcher: {e}")
-            self._control_owner_watcher = None
-
     def _undeclare(self, entity, label: str):
         """Best-effort undeclare for Zenoh entities during shutdown."""
         if entity is None:
@@ -469,13 +401,6 @@ class HandBridge:
             close()
         except Exception as e:
             logger.debug(f"Failed to close Zenoh session: {e}")
-
-    def _get_requester_id(self, message) -> Optional[str]:
-        """Extract requester ZID from a query/sample attachment."""
-        requester = decode_zenoh_text(getattr(message, "attachment", None))
-        if requester:
-            return requester
-        return None
 
     def _start_realtime_controller(self):
         """Enable joints and start realtime controller (raw passthrough)."""
@@ -581,14 +506,7 @@ class HandBridge:
             ))
             logger.info("@capability queryable declared")
 
-            # 5. Control queryable
-            self._queryables.append(self.session.declare_queryable(
-                self._key("@control"),
-                self._handle_control,
-            ))
-            logger.info("@control queryable declared")
-
-            # 6. Resource queryables (GET/SET)
+            # 5. Resource queryables (GET/SET)
             for r in RESOURCE_DEFS:
                 if r["can_get"] or r["can_set"]:
                     q = self.session.declare_queryable(
@@ -598,7 +516,7 @@ class HandBridge:
                     self._queryables.append(q)
                     logger.info(f"Resource queryable: {r['path']}")
 
-            # 7. Subscribe to target_position for fire-and-forget writes (low latency)
+            # 6. Subscribe to target_position for fire-and-forget writes (low latency)
             target_pos_sub = self.session.declare_subscriber(
                 self._key("joint/target_position"),
                 self._handle_target_position_put,
@@ -606,7 +524,7 @@ class HandBridge:
             self._subscribers.append(target_pos_sub)
             logger.info("target_position subscriber declared (fire-and-forget path)")
 
-            # 8. SUB publishers (continuous streams)
+            # 7. SUB publishers (continuous streams)
             for r in RESOURCE_DEFS:
                 if r["can_sub"]:
                     pub = self.session.declare_publisher(self._key(r["path"]))
@@ -641,10 +559,6 @@ class HandBridge:
         except Exception as e:
             logger.warning(f"Failed to stop realtime controller: {e}")
 
-        with self._control_lock:
-            self._control_owner = None
-        self._stop_owner_watcher()
-
         session = self.session
         if session is not None:
             try:
@@ -669,78 +583,15 @@ class HandBridge:
         self._close_session(session)
         logger.info("Bridge stopped")
 
-    def _handle_control(self, query):
-        """Handle @control acquire/release protocol with liveliness-based TTL.
-
-        When control is acquired, a liveliness subscriber watches the owner's
-        presence. If the owner process crashes (liveliness token dropped),
-        control is automatically released.
-        """
-        key = self._key("@control")
-        payload = bytes(query.payload) if query.payload else b""
-        payload_str = payload.decode("utf-8", errors="replace")
-
-        if payload_str.startswith("acquire:"):
-            requester = payload_str[len("acquire:"):]
-            attachment_requester = self._get_requester_id(query)
-            if attachment_requester != requester:
-                query.reply_err(b"identity_mismatch")
-                logger.warning(
-                    "Control acquire rejected: payload requester %r != attachment requester %r",
-                    requester,
-                    attachment_requester,
-                )
-                return
-            with self._control_lock:
-                current_owner = self._control_owner
-                if current_owner is not None and current_owner != requester:
-                    query.reply(key, f"denied:{current_owner}".encode())
-                    logger.info(f"Control denied to {requester}, owner: {current_owner}")
-                    return
-                # Reserve control so competing acquire requests stay serialized while
-                # we establish the liveliness watcher.
-                self._control_owner = requester
-
-            try:
-                self._start_owner_watcher(requester)
-                with self._control_lock:
-                    if self._control_owner != requester:
-                        raise RuntimeError("control owner lost before acquire completed")
-                query.reply(key, b"granted")
-                logger.info(f"Control granted to {requester}")
-            except Exception as e:
-                with self._control_lock:
-                    if self._control_owner == requester:
-                        self._control_owner = None
-                self._stop_owner_watcher()
-                query.reply_err(str(e).encode())
-                logger.error(f"Control acquire failed for {requester}: {e}")
-        elif payload_str.startswith("release:"):
-            requester = payload_str[len("release:"):]
-            attachment_requester = self._get_requester_id(query)
-            if attachment_requester != requester:
-                query.reply_err(b"identity_mismatch")
-                logger.warning(
-                    "Control release rejected: payload requester %r != attachment requester %r",
-                    requester,
-                    attachment_requester,
-                )
-                return
-            with self._control_lock:
-                if self._control_owner == requester:
-                    self._control_owner = None
-                    self._stop_owner_watcher()
-                    query.reply(key, b"released")
-                    logger.info(f"Control released by {requester}")
-                else:
-                    query.reply(key, b"not_owner")
-        else:
-            with self._control_lock:
-                owner = self._control_owner or "none"
-            query.reply(key, owner.encode())
-
     def _handle_resource_query(self, query, resource_def):
-        """Handle GET/SET for a resource."""
+        """Handle GET/SET for a resource.
+
+        Note: write operations (SET / target_position PUT) are no longer gated
+        by an `@control` acquire/release handshake. Any client that can reach
+        this bridge via Zenoh may write. Single-writer protection, if needed,
+        must be enforced by the deployment topology (e.g. firewall rules,
+        Zenoh access control).
+        """
         key = self._key(resource_def["path"])
         payload = bytes(query.payload) if query.payload else b""
 
@@ -760,25 +611,6 @@ class HandBridge:
             if not resource_def["can_set"]:
                 query.reply_err(b"SET not supported")
                 return
-            requester = self._get_requester_id(query)
-            with self._control_lock:
-                owner = self._control_owner
-            if owner is None:
-                query.reply_err(b"no control owner")
-                return
-            if requester is None:
-                query.reply_err(b"missing requester id")
-                logger.warning(f"SET {resource_def['path']} rejected: missing requester attachment")
-                return
-            if requester != owner:
-                query.reply_err(b"not control owner")
-                logger.warning(
-                    "SET %s rejected: requester %s != owner %s",
-                    resource_def["path"],
-                    requester,
-                    owner,
-                )
-                return
             try:
                 value = json.loads(payload.decode("utf-8"))
                 self._write_resource(resource_def["path"], value)
@@ -788,24 +620,12 @@ class HandBridge:
                 query.reply_err(str(e).encode())
 
     def _handle_target_position_put(self, sample):
-        """Handle fire-and-forget PUT for target_position (low-latency path)."""
+        """Handle fire-and-forget PUT for target_position (low-latency path).
+
+        See `_handle_resource_query` for the rationale on dropping the
+        per-write control-owner check.
+        """
         try:
-            requester = self._get_requester_id(sample)
-            with self._control_lock:
-                owner = self._control_owner
-            if owner is None:
-                logger.warning("Ignoring target_position PUT without control owner")
-                return
-            if requester is None:
-                logger.warning("Ignoring target_position PUT without requester attachment")
-                return
-            if requester != owner:
-                logger.warning(
-                    "Ignoring target_position PUT from non-owner requester %s (owner=%s)",
-                    requester,
-                    owner,
-                )
-                return
             value = json.loads(bytes(sample.payload).decode("utf-8"))
             self._write_resource("joint/target_position", value)
         except ValueError as e:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -329,7 +329,7 @@ def test_capability_sub_resources_have_timestamp_schema():
 # Resource query / fire-and-forget PUT tests
 #
 # Note: writes are no longer gated by an `@control` acquire/release handshake,
-# so SET / target_position PUT succeed without any control-권 setup.
+# so SET / target_position PUT succeed without any acquire/release setup.
 # ---------------------------------------------------------------------------
 
 def test_handle_resource_query_get_replies_with_raw_json():

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -326,135 +326,11 @@ def test_capability_sub_resources_have_timestamp_schema():
 
 
 # ---------------------------------------------------------------------------
-# Control TTL tests
+# Resource query / fire-and-forget PUT tests
+#
+# Note: writes are no longer gated by an `@control` acquire/release handshake,
+# so SET / target_position PUT succeed without any control-권 setup.
 # ---------------------------------------------------------------------------
-
-def test_control_acquire_sets_owner():
-    hand = MagicMock()
-    bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    bridge.session = MagicMock()
-    # Simulate acquire
-    with bridge._control_lock:
-        bridge._control_owner = "zid_123"
-    assert bridge._control_owner == "zid_123"
-
-
-def test_control_release_clears_owner():
-    hand = MagicMock()
-    bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    bridge.session = MagicMock()
-    bridge._control_owner = "zid_123"
-    with bridge._control_lock:
-        bridge._control_owner = None
-    assert bridge._control_owner is None
-
-
-def test_control_owner_watcher_key():
-    hand = MagicMock()
-    bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    key = bridge._control_owner_key("zid_abc123")
-    assert key == "wuji/TEST/@control_owner/zid_abc123"
-
-
-def test_stop_owner_watcher_cleans_up():
-    hand = MagicMock()
-    bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    mock_watcher = MagicMock()
-    bridge._control_owner_watcher = mock_watcher
-    bridge._stop_owner_watcher()
-    mock_watcher.undeclare.assert_called_once()
-    assert bridge._control_owner_watcher is None
-
-
-def test_stop_owner_watcher_noop_when_none():
-    hand = MagicMock()
-    bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    bridge._control_owner_watcher = None
-    bridge._stop_owner_watcher()  # should not raise
-    assert bridge._control_owner_watcher is None
-
-
-def test_stop_owner_watcher_logs_debug_on_undeclare_error():
-    hand = MagicMock()
-    bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    mock_watcher = MagicMock()
-    mock_watcher.undeclare.side_effect = RuntimeError("boom")
-    bridge._control_owner_watcher = mock_watcher
-
-    with patch.object(hand_zenoh_bridge_module.logger, "debug") as debug_mock:
-        bridge._stop_owner_watcher()
-
-    debug_mock.assert_called_once_with("Failed to undeclare owner watcher: boom")
-    assert bridge._control_owner_watcher is None
-
-
-def test_start_owner_watcher_raises_when_subscriber_creation_returns_none():
-    hand = MagicMock()
-    bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    bridge.session = MagicMock()
-    bridge.session.liveliness.return_value.declare_subscriber.return_value = None
-
-    with pytest.raises(RuntimeError, match="declare_subscriber returned None"):
-        bridge._start_owner_watcher("zid_123")
-
-    assert bridge._control_owner_watcher is None
-
-
-def test_start_owner_watcher_releases_owner_on_delete_sample(monkeypatch):
-    hand = MagicMock()
-    bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    bridge.session = MagicMock()
-    delete_kind = object()
-    monkeypatch.setattr(hand_zenoh_bridge_module.zenoh, "SampleKind", MagicMock(DELETE=delete_kind))
-
-    captured = {}
-    watcher = MagicMock()
-
-    def declare_subscriber(_key, callback):
-        captured["callback"] = callback
-        return watcher
-
-    bridge.session.liveliness.return_value.declare_subscriber.side_effect = declare_subscriber
-    bridge._control_owner = "zid_123"
-    bridge._start_owner_watcher("zid_123")
-
-    sample = MagicMock()
-    sample.kind = delete_kind
-    captured["callback"](sample)
-
-    assert bridge._control_owner is None
-    watcher.undeclare.assert_called_once()
-    assert bridge._control_owner_watcher is None
-
-
-def test_handle_control_acquire_rolls_back_when_watcher_start_fails():
-    hand = MagicMock()
-    bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    bridge._start_owner_watcher = MagicMock(side_effect=RuntimeError("boom"))
-    query = MagicMock()
-    query.payload = b"acquire:zid_123"
-    query.attachment = b"zid_123"
-
-    bridge._handle_control(query)
-
-    assert bridge._control_owner is None
-    query.reply.assert_not_called()
-    query.reply_err.assert_called_once_with(b"boom")
-
-
-def test_handle_control_rejects_attachment_mismatch():
-    hand = MagicMock()
-    bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    query = MagicMock()
-    query.payload = b"acquire:zid_123"
-    query.attachment = b"zid_other"
-
-    bridge._handle_control(query)
-
-    assert bridge._control_owner is None
-    query.reply.assert_not_called()
-    query.reply_err.assert_called_once_with(b"identity_mismatch")
-
 
 def test_handle_resource_query_get_replies_with_raw_json():
     hand = MagicMock()
@@ -472,72 +348,42 @@ def test_handle_resource_query_get_replies_with_raw_json():
     assert json.loads(reply_payload.decode("utf-8")) == 12.5
 
 
-def test_handle_resource_query_set_requires_requester_attachment():
+def test_handle_resource_query_set_succeeds_without_attachment():
+    """SET no longer requires a requester attachment or @control acquire."""
     hand = MagicMock()
     bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    bridge._control_owner = "zid_123"
     query = MagicMock()
     query.payload = json.dumps([[True] * 4 for _ in range(5)]).encode("utf-8")
-    query.attachment = None
+    query.attachment = None  # no acquire, no attachment — should still go through
     resource_def = {"path": "joint/enabled", "can_get": False, "can_set": True}
 
     bridge._handle_resource_query(query, resource_def)
 
-    hand.write_joint_enabled.assert_not_called()
-    query.reply.assert_not_called()
-    query.reply_err.assert_called_once_with(b"missing requester id")
-
-
-def test_handle_resource_query_set_rejects_non_owner_requester():
-    hand = MagicMock()
-    bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    bridge._control_owner = "zid_owner"
-    query = MagicMock()
-    query.payload = json.dumps([[True] * 4 for _ in range(5)]).encode("utf-8")
-    query.attachment = b"zid_other"
-    resource_def = {"path": "joint/enabled", "can_get": False, "can_set": True}
-
-    bridge._handle_resource_query(query, resource_def)
-
-    hand.write_joint_enabled.assert_not_called()
-    query.reply.assert_not_called()
-    query.reply_err.assert_called_once_with(b"not control owner")
+    hand.write_joint_enabled.assert_called_once()
+    query.reply_err.assert_not_called()
+    reply_key, reply_payload = query.reply.call_args[0]
+    assert reply_key == "wuji/TEST/joint/enabled"
+    assert reply_payload == b'"ok"'
 
 
 def test_handle_target_position_put_updates_rt_target():
     hand = MagicMock()
     bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    bridge._control_owner = "zid_123"
     sample = MagicMock()
     sample.payload = json.dumps([[0.25] * 4 for _ in range(5)]).encode("utf-8")
-    sample.attachment = b"zid_123"
+    sample.attachment = None  # no acquire / no attachment — still accepted
 
     bridge._handle_target_position_put(sample)
 
     np.testing.assert_array_almost_equal(bridge._rt_target, np.full((5, 4), 0.25))
 
 
-def test_handle_target_position_put_ignores_without_control_owner():
-    hand = MagicMock()
-    bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    sample = MagicMock()
-    sample.payload = json.dumps([[0.25] * 4 for _ in range(5)]).encode("utf-8")
-    sample.attachment = b"zid_123"
-
-    with patch.object(hand_zenoh_bridge_module.logger, "warning") as warning_mock:
-        bridge._handle_target_position_put(sample)
-
-    np.testing.assert_array_almost_equal(bridge._rt_target, np.zeros((5, 4)))
-    warning_mock.assert_called_once_with("Ignoring target_position PUT without control owner")
-
-
 def test_handle_target_position_put_logs_warning_for_invalid_shape():
     hand = MagicMock()
     bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    bridge._control_owner = "zid_123"
     sample = MagicMock()
     sample.payload = json.dumps([[1.0] * 4]).encode("utf-8")
-    sample.attachment = b"zid_123"
+    sample.attachment = None
 
     with patch.object(hand_zenoh_bridge_module.logger, "warning") as warning_mock:
         bridge._handle_target_position_put(sample)
@@ -545,32 +391,6 @@ def test_handle_target_position_put_logs_warning_for_invalid_shape():
     warning_mock.assert_called_once_with(
         "Invalid target_position PUT ignored: target_position must be 5x4 array, got shape (1, 4)"
     )
-
-
-def test_handle_target_position_put_rejects_non_owner_attachment():
-    hand = MagicMock()
-    bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    bridge._control_owner = "zid_owner"
-    sample = MagicMock()
-    sample.payload = json.dumps([[0.25] * 4 for _ in range(5)]).encode("utf-8")
-    sample.attachment = b"zid_other"
-
-    with patch.object(hand_zenoh_bridge_module.logger, "warning") as warning_mock:
-        bridge._handle_target_position_put(sample)
-
-    np.testing.assert_array_almost_equal(bridge._rt_target, np.zeros((5, 4)))
-    warning_mock.assert_called_once_with(
-        "Ignoring target_position PUT from non-owner requester %s (owner=%s)",
-        "zid_other",
-        "zid_owner",
-    )
-
-
-def test_bridge_has_control_lock():
-    hand = MagicMock()
-    bridge = HandBridge(hand, "TEST", pub_rate=100.0)
-    assert hasattr(bridge, '_control_lock')
-    assert hasattr(bridge, '_control_owner_watcher')
 
 
 def test_start_cleans_up_partial_state_on_failure(monkeypatch):


### PR DESCRIPTION
## Summary

Companion change to [`wuji-sdk` PR #215](https://github.com/wuji-technology/wuji-sdk-dev/pull/215) which removed the `acquire_control` / `release_control` SDK API and the per-write requester-attachment plumbing. This PR removes the matching server-side protocol from the standalone wujihandpy zenoh bridge so SDK clients can keep reading **and writing** WujiHand resources via Zenoh without an acquire handshake.

Without this PR landing alongside `wuji-sdk` PR #215, every `wuji-sdk` client of WujiHand over Zenoh would be unable to write (`SET joint/enabled`, `PUT joint/target_position`, etc.) — the bridge would reject them with `missing requester id` / `no control owner`.

## What changed

- **Python bridge** (`bridge/python/hand_zenoh_bridge.py`): drop `_handle_control`, `_start_owner_watcher` / `_stop_owner_watcher`, `_control_owner_key`, `_get_requester_id`, the `_control_owner` / `_control_owner_watcher` / `_control_lock` state, and the now-unused `decode_zenoh_text` helper. SET / `target_position` PUT handlers proceed directly to the underlying write.
- **C++ bridge** (`bridge/cpp/src/hand_bridge.{cpp,hpp}`): matching removal of `handle_control`, `start_owner_watcher` / `stop_owner_watcher`, `control_owner_key`, `control_owner_` / `control_mutex_` / `control_owner_watcher_`, `requester_id_from_attachment`, and the now-unused `log_warn` helper.
- **Tests** (`tests/test_bridge.py`): remove 14 control-권 / attachment / owner-watcher unit tests; add one positive test confirming SET succeeds without a requester attachment.
- **Docs** (`bridge/README.md`): replace the "Control Protocol" section with a "Write Access" note explaining that single-writer protection is now a deployment-topology concern (firewall / Zenoh ACL / isolated network), and strip the example code's acquire / release / owner-token boilerplate.
- **CHANGELOG**: Unreleased / Removed entry.

The third-party-bridge disconnect-watcher feature on the SDK side (PR #199 absorbed via PR #206) is unrelated and continues to work — it gives `wuji-sdk` clients a \`Disconnected\` event whenever this bridge dies.

## Test plan

- [x] \`python3 -m pytest tests/test_bridge.py -q\` → \`33 passed\`
- [x] \`cmake --build bridge/cpp/build -j$(nproc)\` → \`Built target wujihand_zenoh_bridge\` (clean, no warnings from new code)
- [x] \`python3 -c "import bridge.python.hand_zenoh_bridge"\` → import OK, no orphan attribute references
- [x] **End-to-end smoke against a real one-gen WujiHand** (LQSQJR.251129.002):
  - Started Python bridge (\`PYTHONPATH=. python -m bridge.python.hand_zenoh_bridge --pub-rate 100 --side left\`)
  - Ran \`wuji-sdk\` smoke test (\`cargo run --example wujihand_zenoh_smoke\` from PR #215 branch)
  - SDK reported: \`Connected via Zenoh\` → \`GET joint/actual_position OK (436 bytes)\` → \`SET joint/enabled = false OK (no acquire_control() call)\` → \`PUT joint/target_position sent\` → \`=== Smoke test complete: read + write paths both green ===\`
  - Bridge log: no \`Ignoring target_position PUT ...\`, no \`no control owner\`, no \`missing requester id\` — bridge silently accepted SET + PUT without any control-권 dance
- [ ] CI: \`cmake --build\` + \`pytest\` (will run on PR push)

Resolve SWD-1132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **功能改进**
  * 简化写入流程：SET/PUT 写入不再需控制握手，可进行低延迟写入。

* **移除**
  * 删除基于控制（acquire/release）的控制协议说明与示例。

* **文档更新**
  * 更新变更日志与 README，说明写入保护须通过外部拓扑/ACL 等手段保障。

* **测试**
  * 调整测试以反映新的写入行为、权限变化和错误处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->