### PR TITLE
docs(sdk): document log location in troubleshooting

### DIFF
--- a/docs/external/en/introduction.mdx
+++ b/docs/external/en/introduction.mdx
@@ -178,3 +178,7 @@ Please check the Linux udev configuration section in [Installation](#21-installa
 <Callout type="warning">
   Note: If developing in a Docker container (DevContainer), the udev configuration commands must still be executed on the host machine.
 </Callout>
+
+### 5.3 Get Logs
+
+SDK runtime logs are stored in `~/.wuji/log/`. When you run into issues, send the latest log to support to help diagnose the problem.

--- a/docs/external/en/introduction.mdx
+++ b/docs/external/en/introduction.mdx
@@ -181,4 +181,4 @@ Please check the Linux udev configuration section in [Installation](#21-installa
 
 ### 5.3 Get Logs
 
-SDK runtime logs are stored in `~/.wuji/log/`. When you run into issues, send the latest log to support to help diagnose the problem.
+SDK runtime logs are stored in `~/.wuji/log/`. Share the latest log with customer support when reporting an issue.

--- a/docs/external/en/introduction.mdx
+++ b/docs/external/en/introduction.mdx
@@ -181,4 +181,4 @@ Please check the Linux udev configuration section in [Installation](#21-installa
 
 ### 5.3 Get Logs
 
-SDK runtime logs are stored in `~/.wuji/log/`. Share the latest log with customer support when reporting an issue.
+SDK runtime logs are stored in `~/.wuji/log/`. Send the latest log to technical support when reporting an issue.

--- a/docs/external/zh/introduction.mdx
+++ b/docs/external/zh/introduction.mdx
@@ -179,3 +179,7 @@ RuntimeError: Failed to init.
 <Callout type="warning">
   注意：若在 Docker 镜像中开发 (DevContainer)，udev 配置命令仍需在宿主机中执行。
 </Callout>
+
+### 5.3 获取日志
+
+SDK 运行日志位于 `~/.wuji/log/`，遇到问题时可将最近的日志发送给售后支持以协助定位。


### PR DESCRIPTION
## Summary

- 在 SDK 入门文档（`docs/external/{zh,en}/introduction.mdx`）的"故障排除"章节末尾追加 `### 5.3 获取日志 / Get Logs` 一节。
- 一句话告知用户：SDK 运行日志位于 `~/.wuji/log/`，遇到问题可发送给售后支持以协助定位。
- 路径已对照源码核实（`wujihandcpp/src/logging/logging.hpp` `default_log_path()`）。

## Test plan

- [x] 中英文位置、措辞、缩进、空行对齐
- [x] 路径 `~/.wuji/log/` 与源码一致
- [x] 本地通过 pr-review-toolkit code-reviewer 评审，无阻断问题

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 在故障排除章节增加“获取日志”小节，说明 SDK 运行日志存放位置并指导用户在遇到问题时将最近的日志发送给技术支持以便快速定位与诊断。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wuji-technology/wujihandpy/pull/76)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->