### PR TITLE
feat(example): add glove donning/doffing demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Tactile sensing glove support** (Linux only): top-level `wujihandpy.TactileGlove` plus typed companions `TactileFrame`, `TactileError`, `TactileHandedness`, and POD types for device info, diagnostics, firmware build, and time sync. Pressure frames are `numpy.float32` 24×32 arrays in `[0, 1]` with `NaN` for invalid cells. Hand and TactileGlove can coexist in one process—see `example/joint_with_tactile.py`.
 - Example: `6.disconnect.py` demonstrating USB disconnect handling.
-- Example: `joint/glove_donning.py` — smoothly drive hand to a measured glove donning/doffing pose (thumb adducted across the palm, fingers nearly extended) at 100 Hz with low-pass filtering. Auto-selects the left- or right-hand pose via `read_handedness()`.
+- Added example `joint/glove_donning.py` that smoothly drives the hand to a measured glove donning/doffing pose (thumb adducted across the palm, fingers nearly extended) at 100 Hz with low-pass filtering. Auto-selects the left- or right-hand pose via `read_handedness()`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Tactile sensing glove support** (Linux only): top-level `wujihandpy.TactileGlove` plus typed companions `TactileFrame`, `TactileError`, `TactileHandedness`, and POD types for device info, diagnostics, firmware build, and time sync. Pressure frames are `numpy.float32` 24×32 arrays in `[0, 1]` with `NaN` for invalid cells. Hand and TactileGlove can coexist in one process—see `example/joint_with_tactile.py`.
 - Example: `6.disconnect.py` demonstrating USB disconnect handling.
-- Example: `joint/glove_donning.py` — smoothly drive hand to a measured glove donning/doffing pose (thumb adducted across the palm, fingers nearly extended) at 100 Hz with low-pass filtering.
+- Example: `joint/glove_donning.py` — smoothly drive hand to a measured glove donning/doffing pose (thumb adducted across the palm, fingers nearly extended) at 100 Hz with low-pass filtering. Auto-selects the left- or right-hand pose via `read_handedness()`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Tactile sensing glove support** (Linux only): top-level `wujihandpy.TactileGlove` plus typed companions `TactileFrame`, `TactileError`, `TactileHandedness`, and POD types for device info, diagnostics, firmware build, and time sync. Pressure frames are `numpy.float32` 24×32 arrays in `[0, 1]` with `NaN` for invalid cells. Hand and TactileGlove can coexist in one process—see `example/joint_with_tactile.py`.
 - Example: `6.disconnect.py` demonstrating USB disconnect handling.
+- Example: `joint/glove_donning.py` — smoothly drive hand to a measured glove donning/doffing pose (thumb adducted across the palm, fingers nearly extended) at 100 Hz with low-pass filtering.
 
 ### Changed
 

--- a/example/joint/glove_donning.py
+++ b/example/joint/glove_donning.py
@@ -1,0 +1,43 @@
+"""穿脱手套 demo: 将所有关节平滑归零（手掌摊平），便于穿戴或脱下手套。
+
+低通滤波器从当前位姿插值到目标 0 位，达到稳定时间后自动退出并失能所有关节。
+"""
+
+import time
+
+import numpy as np
+
+import wujihandpy
+
+UPDATE_RATE_HZ = 100.0
+SETTLE_TIME_S = 3.0
+
+
+def main() -> None:
+    hand = wujihandpy.Hand()
+    try:
+        run(hand)
+    finally:
+        hand.write_joint_enabled(False)
+
+
+def run(hand: wujihandpy.Hand) -> None:
+    hand.write_joint_enabled(True)
+
+    target = np.zeros((5, 4), dtype=np.float64)
+    update_period = 1.0 / UPDATE_RATE_HZ
+
+    with hand.realtime_controller(
+        enable_upstream=False,
+        filter=wujihandpy.filter.LowPass(cutoff_freq=2.0),
+    ) as controller:
+        deadline = time.monotonic() + SETTLE_TIME_S
+        while time.monotonic() < deadline:
+            controller.set_joint_target_position(target)
+            time.sleep(update_period)
+
+    print("All joints zeroed. Ready for glove donning/doffing.")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/joint/glove_donning.py
+++ b/example/joint/glove_donning.py
@@ -1,6 +1,8 @@
-"""穿脱手套 demo: 将所有关节平滑归零（手掌摊平），便于穿戴或脱下手套。
+"""穿脱手套 demo: 将所有关节平滑驱至穿戴姿态, 便于穿戴或脱下手套。
 
-低通滤波器从当前位姿插值到目标 0 位，达到稳定时间后自动退出并失能所有关节。
+拇指对掌内收 (F1J1≈1.30, F1J2≈0.75 rad) 贴向掌心, 其余四指基本伸直,
+形成扁平手型给手套留空间。低通滤波器从当前位姿插值到目标位,
+达到稳定时间后自动退出并失能所有关节。
 """
 
 import time
@@ -11,6 +13,18 @@ import wujihandpy
 
 UPDATE_RATE_HZ = 100.0
 SETTLE_TIME_S = 3.0
+
+# 穿戴手套姿态: 实测时手动摆好后从 read_joint_actual_position() 读取得到 (单位: rad)
+GLOVE_DONNING_POSE = np.array(
+    [
+        [1.3029, 0.7528, 0.0190, 0.0082],  # F1 拇指: CMC1/CMC2/PIP/DIP
+        [0.0283, -0.0298, 0.0017, 0.0016],  # F2 食指
+        [0.0427, 0.0098, 0.0116, 0.0071],  # F3 中指
+        [0.0163, 0.0716, 0.0371, 0.0086],  # F4 无名指
+        [-0.0057, 0.1875, 0.0008, -0.0333],  # F5 小指
+    ],
+    dtype=np.float64,
+)
 
 
 def main() -> None:
@@ -23,20 +37,22 @@ def main() -> None:
 
 def run(hand: wujihandpy.Hand) -> None:
     hand.write_joint_enabled(True)
+    try:
+        target = GLOVE_DONNING_POSE.copy()
+        update_period = 1.0 / UPDATE_RATE_HZ
 
-    target = np.zeros((5, 4), dtype=np.float64)
-    update_period = 1.0 / UPDATE_RATE_HZ
+        with hand.realtime_controller(
+            enable_upstream=False,
+            filter=wujihandpy.filter.LowPass(cutoff_freq=2.0),
+        ) as controller:
+            deadline = time.monotonic() + SETTLE_TIME_S
+            while time.monotonic() < deadline:
+                controller.set_joint_target_position(target)
+                time.sleep(update_period)
 
-    with hand.realtime_controller(
-        enable_upstream=False,
-        filter=wujihandpy.filter.LowPass(cutoff_freq=2.0),
-    ) as controller:
-        deadline = time.monotonic() + SETTLE_TIME_S
-        while time.monotonic() < deadline:
-            controller.set_joint_target_position(target)
-            time.sleep(update_period)
-
-    print("All joints zeroed. Ready for glove donning/doffing.")
+        print("Hand in glove donning pose. Ready for glove donning/doffing.")
+    finally:
+        hand.write_joint_enabled(False)
 
 
 if __name__ == "__main__":

--- a/example/joint/glove_donning.py
+++ b/example/joint/glove_donning.py
@@ -1,8 +1,9 @@
 """穿脱手套 demo: 将所有关节平滑驱至穿戴姿态, 便于穿戴或脱下手套。
 
-拇指对掌内收 (F1J1≈1.30, F1J2≈0.75 rad) 贴向掌心, 其余四指基本伸直,
-形成扁平手型给手套留空间。低通滤波器从当前位姿插值到目标位,
-达到稳定时间后自动退出并失能所有关节。
+拇指对掌内收 (F1J1≈1.1-1.3, F1J2≈0.75 rad) 贴向掌心, 其余四指基本伸直,
+形成扁平手型给手套留空间。脚本通过 read_handedness() 自动区分左右手并选择
+对应的标定姿态。低通滤波器从当前位姿插值到目标位, 达到稳定时间后自动退出
+并失能所有关节。
 """
 
 import time
@@ -14,13 +15,28 @@ import wujihandpy
 UPDATE_RATE_HZ = 100.0
 SETTLE_TIME_S = 3.0
 
-# 穿戴手套姿态: 实测时手动摆好后从 read_joint_actual_position() 读取得到 (单位: rad)
-GLOVE_DONNING_POSE = np.array(
+# 固件 handedness 约定: 1 = 左手, 其他 (通常 0) = 右手
+HANDEDNESS_LEFT = 1
+
+# 穿戴手套姿态: 实测时操作员手动摆好后从 read_joint_actual_position() 读取 (单位: rad)
+# 每行对应一根手指 F1-F5 (拇指/食指/中指/无名指/小指), 列对应 J1-J4
+GLOVE_DONNING_POSE_LEFT = np.array(
     [
-        [1.3029, 0.7528, 0.0190, 0.0082],  # F1 拇指: CMC1/CMC2/PIP/DIP
-        [0.0283, -0.0298, 0.0017, 0.0016],  # F2 食指
-        [0.0427, 0.0098, 0.0116, 0.0071],  # F3 中指
-        [0.0163, 0.0716, 0.0371, 0.0086],  # F4 无名指
+        [1.1355, 0.7829, -0.0018, 0.0016],   # F1 拇指: CMC1/CMC2/PIP/DIP
+        [0.0012, 0.0977, 0.0001, 0.0026],    # F2 食指
+        [-0.0016, 0.0002, -0.0033, 0.0020],  # F3 中指
+        [0.0002, -0.1037, 0.0010, 0.0004],   # F4 无名指
+        [-0.0022, -0.1559, -0.0006, 0.0029], # F5 小指
+    ],
+    dtype=np.float64,
+)
+
+GLOVE_DONNING_POSE_RIGHT = np.array(
+    [
+        [1.3029, 0.7528, 0.0190, 0.0082],    # F1 拇指
+        [0.0283, -0.0298, 0.0017, 0.0016],   # F2 食指
+        [0.0427, 0.0098, 0.0116, 0.0071],    # F3 中指
+        [0.0163, 0.0716, 0.0371, 0.0086],    # F4 无名指
         [-0.0057, 0.1875, 0.0008, -0.0333],  # F5 小指
     ],
     dtype=np.float64,
@@ -36,9 +52,16 @@ def main() -> None:
 
 
 def run(hand: wujihandpy.Hand) -> None:
+    if hand.read_handedness() == HANDEDNESS_LEFT:
+        target = GLOVE_DONNING_POSE_LEFT.copy()
+        side = "left"
+    else:
+        target = GLOVE_DONNING_POSE_RIGHT.copy()
+        side = "right"
+    print(f"Detected {side} hand, driving to glove donning pose...")
+
     hand.write_joint_enabled(True)
     try:
-        target = GLOVE_DONNING_POSE.copy()
         update_period = 1.0 / UPDATE_RATE_HZ
 
         with hand.realtime_controller(
@@ -50,7 +73,7 @@ def run(hand: wujihandpy.Hand) -> None:
                 controller.set_joint_target_position(target)
                 time.sleep(update_period)
 
-        print("Hand in glove donning pose. Ready for glove donning/doffing.")
+        print(f"Hand ({side}) in glove donning pose. Ready for glove donning/doffing.")
     finally:
         hand.write_joint_enabled(False)
 


### PR DESCRIPTION
## Summary
- 新增 `example/joint/glove_donning.py`：穿脱手套 demo
- 使用 realtime controller + LowPass(2Hz) 平滑插值到全零位（手掌摊平），便于穿戴/脱下手套
- 跑 3 秒让滤波收敛后自动退出，`finally` 块统一失能整手

## Test plan
- [ ] 真机上跑一遍，确认从任意初始位姿都能平滑归零
- [ ] 若 3s 不够（初始位姿离零位较远），调大 `SETTLE_TIME_S`
- [ ] 确认退出后所有关节失能

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增加手套穿脱演示：支持左右手分别的目标姿态选择，在实时控制与低通滤波下以高频率驱动关节，实现平滑、可重复的穿脱就绪动作并在完成时提示就绪。
* **文档**
  * 在变更日志中新增该演示条目，说明演示的运行行为与滤波特性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wuji-technology/wujihandpy/pull/77)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->