### PR TITLE
fix(cmake): link FrameDemuxer into wujihandcpp_tests on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Zenoh Bridge (Python + C++)**: dropped `@control` acquire/release protocol; SET / PUT writes no longer require a handshake.
 
+### Fixed
+
+- Fixed Linux release build (`Dockerfile.package-builder` / cibuildwheel) failing to link `wujihandcpp_tests` with `undefined reference to wujihandcpp::tactile::FrameDemuxer::*`. Root cause was `FrameDemuxer`'s symbols being stripped from `libwujihandcpp.so` by `-fvisibility=hidden` (it's a `src/`-private class with no `visibility("default")` annotation). The test target now compiles `src/device/frame_demuxer.cpp` directly into the executable on Linux + shared-library builds, leaving the library's public ABI unchanged.
+
 ## [1.6.0] - 2026-04-27
 
 ### Changed

--- a/wujihandcpp/CMakeLists.txt
+++ b/wujihandcpp/CMakeLists.txt
@@ -259,7 +259,7 @@ if(BUILD_TESTING)
     # widen the test target's include path here.
     target_include_directories(wujihandcpp_tests PRIVATE ${PROJECT_SOURCE_DIR}/src)
     # FrameDemuxer is intentionally a src/-private class (no
-    # visibility("default")) and the lib is compiled with
+    # visibility("default")) and the SHARED lib is compiled with
     # -fvisibility=hidden, so FrameDemuxer's symbols are stripped from
     # libwujihandcpp.so's dynamic symbol table. Linking the test exe
     # against the .so therefore fails with "undefined reference to
@@ -267,7 +267,13 @@ if(BUILD_TESTING)
     # the test exe so the linker resolves the calls locally, without
     # widening the lib's public ABI. Linux-only — mirrors the
     # PROJECT_SOURCE / TEST_SOURCES platform gates above.
-    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    #
+    # Gated on NOT BUILD_STATIC_WUJIHANDCPP: the static archive keeps all
+    # symbols regardless of visibility, so the test exe can already
+    # resolve FrameDemuxer through ${PROJECT_NAME}. Adding it again
+    # would compile the same TU into both archive and exe → duplicate
+    # symbols at link time.
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT BUILD_STATIC_WUJIHANDCPP)
         target_sources(wujihandcpp_tests PRIVATE
             ${PROJECT_SOURCE_DIR}/src/device/frame_demuxer.cpp
         )

--- a/wujihandcpp/CMakeLists.txt
+++ b/wujihandcpp/CMakeLists.txt
@@ -258,6 +258,20 @@ if(BUILD_TESTING)
     # main lib only exposes include/ to consumers via PUBLIC; we explicitly
     # widen the test target's include path here.
     target_include_directories(wujihandcpp_tests PRIVATE ${PROJECT_SOURCE_DIR}/src)
+    # FrameDemuxer is intentionally a src/-private class (no
+    # visibility("default")) and the lib is compiled with
+    # -fvisibility=hidden, so FrameDemuxer's symbols are stripped from
+    # libwujihandcpp.so's dynamic symbol table. Linking the test exe
+    # against the .so therefore fails with "undefined reference to
+    # FrameDemuxer::*". Compile the same translation unit directly into
+    # the test exe so the linker resolves the calls locally, without
+    # widening the lib's public ABI. Linux-only — mirrors the
+    # PROJECT_SOURCE / TEST_SOURCES platform gates above.
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        target_sources(wujihandcpp_tests PRIVATE
+            ${PROJECT_SOURCE_DIR}/src/device/frame_demuxer.cpp
+        )
+    endif()
     target_link_libraries(wujihandcpp_tests PRIVATE gtest_main ${PROJECT_NAME})
 
     add_test(NAME wujihandcpp_tests COMMAND wujihandcpp_tests)


### PR DESCRIPTION
## Summary

修复 v1.7.0 release CI 在 Linux 上的链接错误：

```
undefined reference to `wujihandcpp::tactile::FrameDemuxer::command(...)`
undefined reference to `wujihandcpp::tactile::FrameDemuxer::wait_data_frame(...)`
... (等 FrameDemuxer 的 ctor / dtor / start / stop)
```

**根因**：`wujihandcpp` 用 `-fvisibility=hidden` 编译，`FrameDemuxer` 是 `src/` 私有类（无 `visibility("default")` 注解，也没有公开头文件），所以它的符号被从 `libwujihandcpp.so` 的 dynamic symbol table 里剥掉了。`wujihandcpp_tests` 链接 `.so` 时找不到这些符号。

**修复**：在 Linux 上把 `src/device/frame_demuxer.cpp` 直接编进 `wujihandcpp_tests` 可执行文件，让链接器从本地 object 解析，不需要把这个私有类暴露到 lib 的 public ABI。镜像已有的平台门控写法（macOS / Windows 上 `.cpp` 和测试文件都已被 `list(FILTER ... EXCLUDE)` 排除）。

仅触及 `wujihandcpp/CMakeLists.txt`（+14 行），不动任何 C++ 源码 / 公开 API。

## Test plan

- [x] 本地用 CI 同款 `quay.io/pypa/manylinux_2_28_x86_64` 镜像复现 v1.7.0 的链接错误
- [x] Apply 本 PR，重跑同样镜像 + 同样 cmake 命令：`[100%] Linking CXX executable wujihandcpp_tests` ✅
- [x] 产物正常：`libwujihandcpp.so` (2.0 MB) + `wujihandcpp_tests` (1.1 MB)
- [ ] CI release-package.yml 在 ubuntu-latest / ubuntu-24.04-arm 两个 job 都通过 build wujihandcpp 步骤
- [ ] macOS / Windows 行为不变（这些平台上 frame_demuxer.cpp 和 frame_demuxer_test.cpp 仍被 filter，新加的 `if(CMAKE_SYSTEM_NAME STREQUAL "Linux")` 不会激活）

## Follow-up

修复 merge 后，v1.7.0 发版无法补救（PyPI 没发出去 + tag 已存在）。建议直接 bump 到 v1.7.1 重新走 release 流程。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了在 Linux + 共享库构建下导致测试可执行文件链接失败的问题；调整了测试构建逻辑以确保该平台上测试可成功构建并运行，同时避免在静态库构建时重复编译同一源码单元引发的符号冲突。

* **Documentation**
  * 在发布说明中新增修复条目，说明已解决的 Linux 构建/测试问题及其影响。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wuji-technology/wujihandpy/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->