### PR TITLE
chore(example): renumber glove_donning to 7.glove_donning + English comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Tactile sensing glove support** (Linux only): top-level `wujihandpy.TactileGlove` plus typed companions `TactileFrame`, `TactileError`, `TactileHandedness`, and POD types for device info, diagnostics, firmware build, and time sync. Pressure frames are `numpy.float32` 24×32 arrays in `[0, 1]` with `NaN` for invalid cells. Hand and TactileGlove can coexist in one process—see `example/joint_with_tactile.py`.
 - Added example `6.disconnect.py` demonstrating USB disconnect handling.
-- Added example `joint/glove_donning.py` that smoothly drives the hand to a measured glove donning/doffing pose (thumb adducted across the palm, fingers nearly extended) at 100 Hz with low-pass filtering. Auto-selects the left- or right-hand pose via `read_handedness()`.
+- Added example `joint/7.glove_donning.py` that smoothly drives the hand to a measured glove donning/doffing pose (thumb adducted across the palm, fingers nearly extended) at 100 Hz with low-pass filtering. Auto-selects the left- or right-hand pose via `read_handedness()`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ Wuji Hand SDK: C++ core with Python bindings, for controlling and communicating 
 │   ├── main.cpp
 │   └── *.hpp
 ├── example/                      # Usage examples
-│   ├── joint/                    # read / write / realtime / async / multithread / disconnect
+│   ├── joint/                    # read / write / realtime / async / multithread / disconnect / glove donning
 │   │   ├── 1.read.py
 │   │   ├── 2.write.py
 │   │   ├── 3.realtime.py
 │   │   ├── 4.async.py
 │   │   ├── 5.multithread.py
-│   │   └── 6.disconnect.py
+│   │   ├── 6.disconnect.py
+│   │   └── 7.glove_donning.py
 │   ├── tactile/                  # Tactile sensing glove
 │   │   └── basic.py
 │   └── joint_with_tactile.py     # Drive both subsystems together

--- a/example/joint/7.glove_donning.py
+++ b/example/joint/7.glove_donning.py
@@ -1,9 +1,10 @@
-"""穿脱手套 demo: 将所有关节平滑驱至穿戴姿态, 便于穿戴或脱下手套。
+"""Glove donning/doffing demo: smoothly drive all joints to a wear-ready pose.
 
-拇指对掌内收 (F1J1≈1.1-1.3, F1J2≈0.75 rad) 贴向掌心, 其余四指基本伸直,
-形成扁平手型给手套留空间。脚本通过 read_handedness() 自动区分左右手并选择
-对应的标定姿态。低通滤波器从当前位姿插值到目标位, 达到稳定时间后自动退出
-并失能所有关节。
+The thumb is adducted across the palm (F1J1 ~1.1-1.3, F1J2 ~0.75 rad) while
+the other four fingers stay nearly extended, leaving room for the glove.
+The script uses read_handedness() to pick the matching calibration pose for
+the left or right hand. A low-pass filter interpolates from the current
+pose to the target, then disables all joints after the settle time elapses.
 """
 
 import time
@@ -15,29 +16,30 @@ import wujihandpy
 UPDATE_RATE_HZ = 100.0
 SETTLE_TIME_S = 3.0
 
-# 固件 handedness 约定: 1 = 左手, 其他 (通常 0) = 右手
+# Firmware handedness convention: 1 = left hand, others (typically 0) = right hand
 HANDEDNESS_LEFT = 1
 
-# 穿戴手套姿态: 实测时操作员手动摆好后从 read_joint_actual_position() 读取 (单位: rad)
-# 每行对应一根手指 F1-F5 (拇指/食指/中指/无名指/小指), 列对应 J1-J4
+# Glove donning pose: captured from read_joint_actual_position() after the
+# operator manually held the hand in place (unit: rad).
+# Rows are fingers F1-F5 (thumb/index/middle/ring/pinky), columns are J1-J4.
 GLOVE_DONNING_POSE_LEFT = np.array(
     [
-        [1.1355, 0.7829, -0.0018, 0.0016],   # F1 拇指: CMC1/CMC2/PIP/DIP
-        [0.0012, 0.0977, 0.0001, 0.0026],    # F2 食指
-        [-0.0016, 0.0002, -0.0033, 0.0020],  # F3 中指
-        [0.0002, -0.1037, 0.0010, 0.0004],   # F4 无名指
-        [-0.0022, -0.1559, -0.0006, 0.0029], # F5 小指
+        [1.1355, 0.7829, -0.0018, 0.0016],   # F1 thumb: CMC1/CMC2/PIP/DIP
+        [0.0012, 0.0977, 0.0001, 0.0026],    # F2 index
+        [-0.0016, 0.0002, -0.0033, 0.0020],  # F3 middle
+        [0.0002, -0.1037, 0.0010, 0.0004],   # F4 ring
+        [-0.0022, -0.1559, -0.0006, 0.0029], # F5 pinky
     ],
     dtype=np.float64,
 )
 
 GLOVE_DONNING_POSE_RIGHT = np.array(
     [
-        [1.3029, 0.7528, 0.0190, 0.0082],    # F1 拇指
-        [0.0283, -0.0298, 0.0017, 0.0016],   # F2 食指
-        [0.0427, 0.0098, 0.0116, 0.0071],    # F3 中指
-        [0.0163, 0.0716, 0.0371, 0.0086],    # F4 无名指
-        [-0.0057, 0.1875, 0.0008, -0.0333],  # F5 小指
+        [1.3029, 0.7528, 0.0190, 0.0082],    # F1 thumb
+        [0.0283, -0.0298, 0.0017, 0.0016],   # F2 index
+        [0.0427, 0.0098, 0.0116, 0.0071],    # F3 middle
+        [0.0163, 0.0716, 0.0371, 0.0086],    # F4 ring
+        [-0.0057, 0.1875, 0.0008, -0.0333],  # F5 pinky
     ],
     dtype=np.float64,
 )


### PR DESCRIPTION
## Summary
Follow-up cleanup to #77.

- 将 `example/joint/glove_donning.py` 重命名为 `example/joint/7.glove_donning.py`，对齐 `1.read.py` … `6.disconnect.py` 的现有编号规范
- 将模块 docstring 与全部行内注释翻译为英文，与 `example/joint/` 下其他示例一致
- `CHANGELOG.md` 中的文件名引用同步更新

无行为变更（pose 数值、控制流程、API 调用均保持不变）。

## Test plan
- [ ] `python example/joint/7.glove_donning.py` 真机上跑一遍，确认行为与 #77 完全一致
- [ ] 浏览 `example/joint/` 目录，确认序号连续 (1-7) 无遗漏

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增手套穿戴示例：演示以约100Hz平滑驱动关节完成穿戴/脱戴，并可自动选择左右手对应姿态。
* **文档**
  * 示例内说明由中文改为英文，增强对平滑控制、左右手选择和滤波插值等行为的描述。
  * 仓库示例列表与说明已更新并重组以反映新增示例。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wuji-technology/wujihandpy/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->