### PR TITLE
fix(cmake): keep spdlog private for shared installs

### DIFF
--- a/tests/test_wujihandcpp_packaging.py
+++ b/tests/test_wujihandcpp_packaging.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import shutil
+import subprocess
+
+
+def run(command):
+    subprocess.run(command, check=True, text=True)
+
+
+def test_shared_standalone_install_does_not_vendor_spdlog(tmp_path):
+    source_dir = Path(__file__).resolve().parents[1] / "wujihandcpp"
+    build_dir = tmp_path / "build"
+    install_prefix = tmp_path / "install"
+
+    configure = [
+        "cmake",
+        "-S",
+        str(source_dir),
+        "-B",
+        str(build_dir),
+        f"-DCMAKE_INSTALL_PREFIX={install_prefix}",
+        "-DBUILD_STATIC_WUJIHANDCPP=OFF",
+        "-DBUILD_TESTING=OFF",
+        "-DWUJIHANDCPP_INSTALL=ON",
+    ]
+    if shutil.which("gcc-13") and shutil.which("g++-13"):
+        configure.extend(["-DCMAKE_C_COMPILER=gcc-13", "-DCMAKE_CXX_COMPILER=g++-13"])
+    if shutil.which("ninja"):
+        configure.extend(["-G", "Ninja"])
+
+    run(configure)
+    run(["cmake", "--build", str(build_dir), "--target", "install", "--parallel", "2"])
+
+    installed_sdk_libs = list(install_prefix.glob("lib*/libwujihandcpp.*"))
+    assert installed_sdk_libs
+
+    vendored_spdlog = (
+        list(install_prefix.glob("include/spdlog/**"))
+        + list(install_prefix.glob("lib*/libspdlog*"))
+        + list(install_prefix.glob("lib*/cmake/spdlog/**"))
+        + list(install_prefix.glob("lib*/pkgconfig/spdlog.pc"))
+    )
+    assert vendored_spdlog == []
+
+    targets_file = next(install_prefix.glob("lib*/cmake/wujihandcpp/wujihandcppTargets.cmake"))
+    assert "spdlog::spdlog" not in targets_file.read_text()

--- a/wujihandcpp/CMakeLists.txt
+++ b/wujihandcpp/CMakeLists.txt
@@ -128,19 +128,20 @@ FetchContent_Declare(
     GIT_TAG v1.16.0
     GIT_SHALLOW TRUE
 )
-# Ship spdlog alongside wujihandcpp when we are installing. Downstream
-# consumers do `find_package(wujihandcpp CONFIG REQUIRED)` which transitively
-# `find_dependency(spdlog)` — that has to resolve, and the simplest place to
-# resolve it is the same prefix wujihandcpp installed into. When wheel /
-# embedding builds set WUJIHANDCPP_INSTALL=OFF, spdlog stays out of the
-# install set too.
-if(WUJIHANDCPP_INSTALL)
+# Ship spdlog only for static installs. Shared-library packages already link
+# the spdlog objects into libwujihandcpp.so, and no public header includes
+# spdlog, so installing it would unnecessarily conflict with system packages.
+if(WUJIHANDCPP_INSTALL AND BUILD_STATIC_WUJIHANDCPP)
     set(SPDLOG_INSTALL ON CACHE BOOL "" FORCE)
 else()
     set(SPDLOG_INSTALL OFF CACHE BOOL "" FORCE)
 endif()
 FetchContent_MakeAvailable(spdlog)
-target_link_libraries(${PROJECT_NAME} PUBLIC spdlog::spdlog)
+if(BUILD_STATIC_WUJIHANDCPP)
+    target_link_libraries(${PROJECT_NAME} PUBLIC spdlog::spdlog)
+else()
+    target_link_libraries(${PROJECT_NAME} PRIVATE spdlog::spdlog)
+endif()
 
 if(NOT MSVC)
     # GCC/Clang

--- a/wujihandcpp/cmake/wujihandcppConfig.cmake.in
+++ b/wujihandcpp/cmake/wujihandcppConfig.cmake.in
@@ -1,27 +1,21 @@
 @PACKAGE_INIT@
 
-# Transitive dependencies of the installed wujihandcpp library. The static
-# archive needs Threads + spdlog symbols at link time even though spdlog is
-# implementation-detail (not in any public header).
+# Transitive dependencies of the installed wujihandcpp library.
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 
-# spdlog discovery: the install-tree path bundles spdlog into the same prefix
-# (SPDLOG_INSTALL=ON in wujihandcpp/CMakeLists.txt) so find_dependency finds
-# it through CMAKE_PREFIX_PATH. The build-tree path (consumers doing
-# `find_package(wujihandcpp PATHS .../build NO_DEFAULT_PATH)` for local dev)
-# does NOT install spdlog, but the FetchContent fetch leaves spdlog's build
-# tree under `_deps/spdlog-build` next to ours. Hint that location so the
-# build-tree consumption flow works on machines without a system spdlog
-# package — otherwise `find_dependency(spdlog)` fails opaquely on a fresh
-# checkout.
-get_filename_component(_WUJIHANDCPP_CONFIG_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-if(EXISTS "${_WUJIHANDCPP_CONFIG_DIR}/_deps/spdlog-build/spdlogConfig.cmake")
-    # Build-tree consumption — spdlog lives where FetchContent put it.
-    list(PREPEND CMAKE_PREFIX_PATH "${_WUJIHANDCPP_CONFIG_DIR}/_deps/spdlog-build")
+# Static archives need spdlog symbols at consumer link time even though spdlog
+# is implementation-detail. Shared installs keep spdlog private and do not
+# require consumers to discover it.
+if(@BUILD_STATIC_WUJIHANDCPP@)
+    get_filename_component(_WUJIHANDCPP_CONFIG_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+    if(EXISTS "${_WUJIHANDCPP_CONFIG_DIR}/_deps/spdlog-build/spdlogConfig.cmake")
+        # Build-tree consumption: spdlog lives where FetchContent put it.
+        list(PREPEND CMAKE_PREFIX_PATH "${_WUJIHANDCPP_CONFIG_DIR}/_deps/spdlog-build")
+    endif()
+    unset(_WUJIHANDCPP_CONFIG_DIR)
+    find_dependency(spdlog)
 endif()
-unset(_WUJIHANDCPP_CONFIG_DIR)
-find_dependency(spdlog)
 
 # usb-1.0 is linked as a bare library name (target_link_libraries(... PUBLIC
 # usb-1.0)) and propagated through the imported target as `-lusb-1.0`. No


### PR DESCRIPTION
## Summary
- keep the CMake Config package flow, but stop shared installs from exporting or installing spdlog
- only expose/install spdlog for static wujihandcpp builds where consumers need the archive dependency
- add a packaging regression test for shared standalone installs

## Test Plan
- pytest -q tests/test_wujihandcpp_packaging.py
- cmake -S wujihandcpp -B build/pkg-spdlog-check -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 -DBUILD_STATIC_WUJIHANDCPP=OFF -DBUILD_TESTING=OFF -DWUJIHANDCPP_INSTALL=ON
- cmake --build build/pkg-spdlog-check --parallel 2
- cpack -G DEB --config build/pkg-spdlog-check/CPackConfig.cmake
- dpkg-deb -c ./wujihandcpp-1.7.0-amd64.deb | rg '(/usr/include/spdlog|/usr/lib.*/libspdlog|/usr/lib.*/cmake/spdlog|/usr/lib.*/pkgconfig/spdlog)' # no matches
- cmake -S wujihandcpp -B build/static-spdlog-check -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 -DCMAKE_INSTALL_PREFIX=$PWD/build/static-spdlog-check/install -DBUILD_STATIC_WUJIHANDCPP=ON -DBUILD_TESTING=OFF -DWUJIHANDCPP_INSTALL=ON
- cmake --build build/static-spdlog-check --target install --parallel 2
- rg -n 'find_dependency\(spdlog\)|spdlog::spdlog' build/static-spdlog-check/install/lib/cmake/wujihandcpp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  * 新增打包测试，验证独立安装场景下的依赖处理正确性

* **改进**
  * 优化CMake构建配置中spdlog依赖的链接策略和安装方式，静态库与共享库构建采用不同的处理方案

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wuji-technology/wujihandpy/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->