### PR TITLE
fix(cmake): restore spdlog as a private implementation detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed wujihandcpp `.deb` package conflict with the system `libspdlog-dev` package (regression from 1.7.0). Installing the 1.7.0 `wujihandcpp-*.deb` on a host that already had `libspdlog-dev` failed with `trying to overwrite '/usr/include/spdlog/async.h', which is also in package libspdlog-dev`. Root cause: PR #63 added `SPDLOG_INSTALL=ON` (so that downstream `find_package(wujihandcpp CONFIG)` could transitively resolve `spdlog`) and linked `spdlog::spdlog` as `PUBLIC`, but spdlog is in fact a private implementation detail — no public header in `wujihandcpp/include/` references it. The vendored spdlog headers were therefore being shipped into `/usr/include/spdlog/`, colliding with `libspdlog-dev`. Fix: link `spdlog::spdlog` as `PRIVATE`, never install spdlog headers, drop `find_dependency(spdlog)` from `wujihandcppConfig.cmake`. For SHARED builds (the `.deb` path and the default `find_package` flow) spdlog symbols stay private to `libwujihandcpp.so` via the platform's default-hidden visibility for non-exported symbols. Resulting `.deb` is also ~54% smaller.
+- Fixed `bridge/cpp` source-build fallback: it forced `BUILD_STATIC_WUJIHANDCPP=ON` without also forcing `WUJIHANDCPP_INSTALL=OFF`, which triggered the new configure-time gate described under Changed below. The system-installed wujihandcpp path also no longer probes for `spdlog::spdlog` — the bridge itself never includes `<spdlog/*>`, and `libwujihandcpp.so` now links spdlog privately.
+
+### Changed
+
+- Removed transitive `spdlog` resolution from `find_package(wujihandcpp CONFIG)`. Consumers that relied on this (none should — spdlog never appeared in any public header) must `find_package(spdlog)` themselves. This restores the pre-1.7.0 contract.
+- Refused `BUILD_STATIC_WUJIHANDCPP=ON` combined with `WUJIHANDCPP_INSTALL=ON` at configure time with an explanatory message. That combination would silently produce an installed Config package that breaks at the consumer's final link step — the vendored spdlog cannot be installed (it would re-introduce the `libspdlog-dev` collision above), and a static archive does not bake spdlog symbols in via PRIVATE link. The two supported combinations are unchanged: `STATIC + INSTALL=OFF` for in-tree embedding (the wheel build and the `bridge/cpp` source-build fallback), and `SHARED + INSTALL=ON` for the system install / `.deb` / `find_package` flow.
+
 ## [1.7.0] - 2026-05-18
 
 ### Added

--- a/bridge/cpp/CMakeLists.txt
+++ b/bridge/cpp/CMakeLists.txt
@@ -32,18 +32,19 @@ if(WUJIHANDCPP_LIB AND WUJIHANDCPP_INCLUDE)
         IMPORTED_LOCATION "${WUJIHANDCPP_LIB}"
         INTERFACE_INCLUDE_DIRECTORIES "${WUJIHANDCPP_INCLUDE}"
     )
-    # wujihandcpp depends on spdlog, libusb, threads
+    # libwujihandcpp.so links spdlog privately (symbols stripped at the .so
+    # boundary via -fvisibility=hidden), so consumers only see the two
+    # genuinely transitive deps. The bridge itself never includes <spdlog/*>.
     find_package(Threads REQUIRED)
-    find_package(spdlog QUIET)
-    if(spdlog_FOUND)
-        target_link_libraries(wujihandcpp INTERFACE spdlog::spdlog Threads::Threads usb-1.0)
-    else()
-        # spdlog bundled in system lib, just link transitive deps
-        target_link_libraries(wujihandcpp INTERFACE Threads::Threads usb-1.0)
-    endif()
+    target_link_libraries(wujihandcpp INTERFACE Threads::Threads usb-1.0)
 else()
     message(STATUS "System wujihandcpp not found, building from source")
+    # In-tree embedding: BUILD_STATIC=ON gives a single archive linked into
+    # the bridge binary; INSTALL=OFF satisfies wujihandcpp's configure-time
+    # gate (the SHARED+INSTALL=ON combination is the one supported for
+    # system packaging) and keeps its bundled spdlog out of any install set.
     set(BUILD_STATIC_WUJIHANDCPP ON CACHE BOOL "" FORCE)
+    set(WUJIHANDCPP_INSTALL OFF CACHE BOOL "" FORCE)
     set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
     add_subdirectory(../../wujihandcpp ${CMAKE_CURRENT_BINARY_DIR}/wujihandcpp)
 endif()

--- a/wujihandcpp/CMakeLists.txt
+++ b/wujihandcpp/CMakeLists.txt
@@ -117,9 +117,32 @@ endif()
 # Install rules are gated so embedding builds (e.g. the wujihandpy Python
 # wheel, which embeds wujihandcpp into _core.so via add_subdirectory) can
 # skip them. Standalone builds (and the system .deb/.rpm packaging path)
-# leave it ON to produce a fully consumable install tree. Declared here —
-# before spdlog FetchContent — so SPDLOG_INSTALL can mirror it.
+# leave it ON to produce a fully consumable install tree.
 option(WUJIHANDCPP_INSTALL "Generate install rules for wujihandcpp" ON)
+
+# Refuse the (static archive + install Config package) combination. A STATIC
+# wujihandcpp.a links spdlog as PRIVATE (see below), so spdlog symbols are
+# not baked into the archive — the consumer's final link step needs them.
+# But we also cannot install our vendored spdlog (it would conflict with
+# libspdlog-dev), so the installed Config package has no way to satisfy that
+# consumer-side link requirement. Fail loud at configure time instead of
+# shipping a Config package that breaks at downstream link.
+#
+# Ordering: both BUILD_STATIC_WUJIHANDCPP (line ~76) and WUJIHANDCPP_INSTALL
+# (just above) must be declared before this check. Anyone refactoring the
+# option() blocks should keep this gate downstream of both.
+if(BUILD_STATIC_WUJIHANDCPP AND WUJIHANDCPP_INSTALL)
+    message(FATAL_ERROR
+        "BUILD_STATIC_WUJIHANDCPP=ON together with WUJIHANDCPP_INSTALL=ON is "
+        "not a supported combination. Pick one:\n"
+        "  (a) BUILD_STATIC_WUJIHANDCPP=ON with WUJIHANDCPP_INSTALL=OFF — for "
+        "      in-tree embedding via add_subdirectory() (the wujihandpy wheel "
+        "      uses this).\n"
+        "  (b) BUILD_STATIC_WUJIHANDCPP=OFF (default — shared library) with "
+        "      WUJIHANDCPP_INSTALL=ON — for the system install / .deb / "
+        "      find_package(wujihandcpp CONFIG) flow."
+    )
+endif()
 
 include(FetchContent)
 FetchContent_Declare(
@@ -128,19 +151,23 @@ FetchContent_Declare(
     GIT_TAG v1.16.0
     GIT_SHALLOW TRUE
 )
-# Ship spdlog alongside wujihandcpp when we are installing. Downstream
-# consumers do `find_package(wujihandcpp CONFIG REQUIRED)` which transitively
-# `find_dependency(spdlog)` — that has to resolve, and the simplest place to
-# resolve it is the same prefix wujihandcpp installed into. When wheel /
-# embedding builds set WUJIHANDCPP_INSTALL=OFF, spdlog stays out of the
-# install set too.
-if(WUJIHANDCPP_INSTALL)
-    set(SPDLOG_INSTALL ON CACHE BOOL "" FORCE)
-else()
-    set(SPDLOG_INSTALL OFF CACHE BOOL "" FORCE)
-endif()
+# spdlog is an implementation detail of wujihandcpp — no public header in
+# include/ references it. Keep its install rules off unconditionally so we
+# never ship spdlog headers under ${CMAKE_INSTALL_INCLUDEDIR}, which would
+# collide with the system libspdlog-dev package on Debian/Ubuntu.
+set(SPDLOG_INSTALL OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(spdlog)
-target_link_libraries(${PROJECT_NAME} PUBLIC spdlog::spdlog)
+
+# Link spdlog as PRIVATE. SHARED build (default, .deb / find_package path):
+# spdlog symbols are kept out of the .so's dynamic symbol table by the
+# platform's default-hidden visibility for non-exported symbols
+# (-fvisibility=hidden on GCC/Clang; default on MSVC), so downstream sees
+# zero spdlog symbols and zero spdlog headers — exactly what an
+# implementation detail should look like. STATIC build path is refused
+# above for install scenarios; in-tree STATIC embedding (e.g. the
+# wujihandpy wheel) resolves spdlog symbols through the in-tree
+# spdlog::spdlog target at final link.
+target_link_libraries(${PROJECT_NAME} PRIVATE spdlog::spdlog)
 
 if(NOT MSVC)
     # GCC/Clang

--- a/wujihandcpp/cmake/wujihandcppConfig.cmake.in
+++ b/wujihandcpp/cmake/wujihandcppConfig.cmake.in
@@ -1,27 +1,15 @@
 @PACKAGE_INIT@
 
-# Transitive dependencies of the installed wujihandcpp library. The static
-# archive needs Threads + spdlog symbols at link time even though spdlog is
-# implementation-detail (not in any public header).
+# Transitive dependencies of the installed wujihandcpp library.
+# Only what the public ABI actually requires is declared here.
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 
-# spdlog discovery: the install-tree path bundles spdlog into the same prefix
-# (SPDLOG_INSTALL=ON in wujihandcpp/CMakeLists.txt) so find_dependency finds
-# it through CMAKE_PREFIX_PATH. The build-tree path (consumers doing
-# `find_package(wujihandcpp PATHS .../build NO_DEFAULT_PATH)` for local dev)
-# does NOT install spdlog, but the FetchContent fetch leaves spdlog's build
-# tree under `_deps/spdlog-build` next to ours. Hint that location so the
-# build-tree consumption flow works on machines without a system spdlog
-# package — otherwise `find_dependency(spdlog)` fails opaquely on a fresh
-# checkout.
-get_filename_component(_WUJIHANDCPP_CONFIG_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-if(EXISTS "${_WUJIHANDCPP_CONFIG_DIR}/_deps/spdlog-build/spdlogConfig.cmake")
-    # Build-tree consumption — spdlog lives where FetchContent put it.
-    list(PREPEND CMAKE_PREFIX_PATH "${_WUJIHANDCPP_CONFIG_DIR}/_deps/spdlog-build")
-endif()
-unset(_WUJIHANDCPP_CONFIG_DIR)
-find_dependency(spdlog)
+# spdlog is intentionally NOT a transitive dependency. It is vendored inside
+# wujihandcpp via FetchContent and linked PRIVATE; its symbols are private
+# to libwujihandcpp.so via -fvisibility=hidden, and no public header in
+# include/ references it. Consumers do not need (and should not depend on)
+# spdlog through wujihandcpp::wujihandcpp.
 
 # usb-1.0 is linked as a bare library name (target_link_libraries(... PUBLIC
 # usb-1.0)) and propagated through the imported target as `-lusb-1.0`. No


### PR DESCRIPTION
## Summary

Fixes a regression in v1.7.0 where installing the wujihandcpp `.deb` package on a host with `libspdlog-dev` failed with:

```
trying to overwrite '/usr/include/spdlog/async.h',
which is also in package libspdlog-dev:amd64 1:1.9.2+ds-0.2
```

### Root cause

PR #63 set `SPDLOG_INSTALL=ON` (so downstream `find_package(wujihandcpp CONFIG)` could transitively resolve spdlog) AND linked `spdlog::spdlog` as `PUBLIC`. But spdlog is in fact a private implementation detail — `grep spdlog wujihandcpp/include/` returns zero matches, and `wujihandcppConfig.cmake.in`'s own comment already conceded "spdlog is implementation-detail (not in any public header)". Installing the vendored 1.16.0 headers into `/usr/include/spdlog/` therefore collided with `libspdlog-dev`.

### Fix

Restore spdlog to its correct private role across all three exposure surfaces — link visibility, install rules, exported Config package:

- Link `spdlog::spdlog` as `PRIVATE` (was `PUBLIC`). SHARED builds keep spdlog symbols out of `libwujihandcpp.so`'s dynamic symbol table via the platform's default-hidden visibility for non-exported symbols (`-fvisibility=hidden` on GCC/Clang; default on MSVC). Downstream sees zero spdlog symbols and zero spdlog headers.
- `SPDLOG_INSTALL` is now unconditionally OFF — never ship vendored spdlog headers under `${CMAKE_INSTALL_INCLUDEDIR}`.
- `wujihandcppConfig.cmake.in` drops `find_dependency(spdlog)` and its build-tree spdlog hint — neither is needed once spdlog is private.
- Add a configure-time `FATAL_ERROR` refusing `BUILD_STATIC_WUJIHANDCPP=ON + WUJIHANDCPP_INSTALL=ON`. That combination would silently produce an installed Config package that breaks at the consumer's final link step (the vendored spdlog can't be installed, and a static archive doesn't bake spdlog symbols in via PRIVATE link). Failing fast at configure time exposes the choice instead of shipping a broken Config.
- Clean up `bridge/cpp/CMakeLists.txt` (the in-repo Zenoh bridge, added in 1.6.0 / #51): source-build fallback now forces `WUJIHANDCPP_INSTALL=OFF` alongside `BUILD_STATIC_WUJIHANDCPP=ON` so it doesn't trip the new gate; the system-installed path no longer probes for spdlog (the bridge source never includes `<spdlog/*>`, and the installed `.so` now links spdlog privately).

### Breaking change classification

This is a patch release. The v1.7.0 contract (`find_package(wujihandcpp CONFIG)` transitively resolves spdlog) was unexercisable in practice — the package fatally conflicted with `libspdlog-dev` at install time, so zero consumers could build against it through the Config path. SemVer permits a patch release to fix a broken prior release.

## Test plan

Host: Ubuntu 22.04 + `libspdlog-dev 1.9.2` + GCC 13.

- [x] SHARED build: 0 warnings / 0 errors
- [x] install staging: 0 spdlog files (baseline: 118)
- [x] `.deb` contents: 0 spdlog entries (baseline: 118); 0 path overlap with `libspdlog-dev` (baseline: 82)
- [x] `.deb` size: 888K → 408K (-54%)
- [x] `sudo dpkg -i fixed .deb` on system with `libspdlog-dev` installed: **succeeds** (baseline: fails with "trying to overwrite")
- [x] downstream `find_package(wujihandcpp CONFIG)` consumer: configure + build + run all pass with zero spdlog dependency
- [x] `STATIC + INSTALL` gate: configure-time `FATAL_ERROR` as designed
- [x] `bridge/cpp` source-build path (`STATIC=ON + INSTALL=OFF`): configures past the gate cleanly
- [x] wheel build + `import wujihandpy`: passes; spdlog still drives internal logs (`[wuji] [info] SDK v1.7.0 initialized`)
- [x] `wujihandcpp` gtest: 1/1 PASS

## Out-of-PR-scope follow-ups (surfaced by ce-code-review)

These are valid testing/docs gaps but warrant separate PRs to keep this fix narrow:

- CI deb-content audit (`dpkg -c *.deb | grep spdlog`) — the exact regression vector has no automated catch today.
- CI `FATAL_ERROR` gate regression test (silent removal would go undetected).
- CI for the `SHARED + INSTALL=ON` build path (`pytest.yml` only exercises wheel / `add_subdirectory`).
- README docs: uncomment the `find_package(wujihandcpp CONFIG REQUIRED)` snippet; add a CMake build-modes table.

## Notes

Two pre-existing weak template instantiations on `spdlog::level::level_enum` remain exported from `libwujihandcpp.so` (template specializations the linker keeps under weak visibility). Tightening would mean funneling through a non-template helper; not in scope for this fix.

Multi-agent review run (correctness, testing, maintainability, project-standards, agent-native, learnings-researcher, api-contract) found the `bridge/cpp/CMakeLists.txt` regression that's included in this PR; without it the `bridge/cpp` source-build fallback would have tripped the new gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复了库安装时与系统 spdlog 头文件的冲突问题。
  * 改进了源码构建配置逻辑，禁止不兼容的构建选项组合。
  * 优化了依赖声明，将内部实现细节私有化，简化下游集成。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wuji-technology/wujihandpy/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->