### PR TITLE
ci: add deb downstream ROS 2 LTS gate

### DIFF
--- a/.github/workflows/deb-downstream-ros2.yml
+++ b/.github/workflows/deb-downstream-ros2.yml
@@ -1,0 +1,94 @@
+name: Deb Downstream ROS 2
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-deb:
+    name: Build wujihandcpp deb
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build wujihandcpp package
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.package-builder
+          outputs: type=local,dest=build/wujihandcpp/
+          cache-from: type=gha,scope=wujihandcpp-deb-downstream
+          cache-to: type=gha,mode=max,scope=wujihandcpp-deb-downstream
+
+      - name: Upload deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wujihandcpp-deb-amd64
+          path: build/wujihandcpp/*.deb
+          if-no-files-found: error
+          retention-days: 7
+
+  downstream-ros2-lts:
+    name: wujihandros2 (${{ matrix.ros_distro }} / Ubuntu ${{ matrix.ubuntu }})
+    runs-on: ubuntu-latest
+    needs: build-deb
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ros_distro: humble
+            ubuntu: "22.04"
+            image: ros:humble-ros-base
+          - ros_distro: jazzy
+            ubuntu: "24.04"
+            image: ros:jazzy-ros-base
+          - ros_distro: lyrical
+            ubuntu: "26.04"
+            image: ros:lyrical-ros-base
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Download deb artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: wujihandcpp-deb-amd64
+          path: build/wujihandcpp
+
+      - name: Install deb and build wujihandros2
+        run: |
+          mapfile -t debs < <(find build/wujihandcpp -maxdepth 1 -type f -name '*.deb' | sort)
+          if [[ "${#debs[@]}" -ne 1 ]]; then
+            printf 'Expected exactly one deb package, found %s:\n' "${#debs[@]}"
+            printf '  %s\n' "${debs[@]}"
+            exit 1
+          fi
+
+          docker run --rm \
+            -v "${PWD}:/work" \
+            -w /work \
+            -e ROS_DISTRO="${{ matrix.ros_distro }}" \
+            "${{ matrix.image }}" \
+            bash -euxo pipefail -c './ci/check_wujihandros2_downstream.sh "$1"' \
+            -- "/work/${debs[0]}"

--- a/ci/check_wujihandros2_downstream.sh
+++ b/ci/check_wujihandros2_downstream.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 /path/to/wujihandcpp.deb" >&2
+  exit 2
+fi
+
+if [[ -z "${ROS_DISTRO:-}" ]]; then
+  echo "ROS_DISTRO must be set" >&2
+  exit 2
+fi
+
+deb_package="$1"
+if [[ ! -f "${deb_package}" || "${deb_package}" != *.deb ]]; then
+  echo "deb package not found: ${deb_package}" >&2
+  exit 2
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y --no-install-recommends \
+  build-essential \
+  ca-certificates \
+  cmake \
+  git \
+  pkg-config \
+  python3-colcon-common-extensions \
+  python3-rosdep
+
+apt-get install -y "${deb_package}"
+dpkg -s wujihandcpp
+
+installed_files="$(mktemp)"
+dpkg -L wujihandcpp | tee "${installed_files}"
+if grep -E '(^|/)spdlog(/|$)|(^|/)libspdlog|(^|/)spdlog[.]pc$|(^|/)cmake/spdlog(/|$)' "${installed_files}"; then
+  echo "wujihandcpp deb unexpectedly installed spdlog files" >&2
+  exit 1
+fi
+
+cmake_dirs=()
+while IFS= read -r dir; do
+  cmake_dirs+=("${dir}")
+done < <(find /usr/lib /usr/lib64 -type d -path '*/cmake/wujihandcpp' 2>/dev/null | sort)
+if [[ "${#cmake_dirs[@]}" -eq 0 ]]; then
+  echo "wujihandcpp CMake package directory not found" >&2
+  exit 1
+fi
+if grep -R 'spdlog::spdlog' "${cmake_dirs[@]}"; then
+  echo "wujihandcpp CMake export unexpectedly exposes spdlog::spdlog" >&2
+  exit 1
+fi
+
+sdk_lib="$(find /usr/lib /usr/lib64 -type f -name 'libwujihandcpp.so*' 2>/dev/null | sort | head -n 1)"
+if [[ -z "${sdk_lib}" ]]; then
+  echo "libwujihandcpp.so not found after installing deb" >&2
+  exit 1
+fi
+ldd "${sdk_lib}"
+if ldd "${sdk_lib}" | grep -E 'not found'; then
+  echo "libwujihandcpp.so has unresolved dynamic dependencies" >&2
+  exit 1
+fi
+
+consumer_dir="$(mktemp -d)"
+cat >"${consumer_dir}/CMakeLists.txt" <<'CMAKE'
+cmake_minimum_required(VERSION 3.16)
+project(wujihandcpp_deb_consumer LANGUAGES CXX)
+
+find_package(wujihandcpp CONFIG REQUIRED)
+
+add_executable(wujihandcpp_deb_consumer main.cpp)
+target_compile_features(wujihandcpp_deb_consumer PRIVATE cxx_std_11)
+target_link_libraries(wujihandcpp_deb_consumer PRIVATE wujihandcpp::wujihandcpp)
+CMAKE
+cat >"${consumer_dir}/main.cpp" <<'CPP'
+#include <wujihandcpp/data/joint.hpp>
+#include <wujihandcpp/utility/logging.hpp>
+
+int main() {
+    wujihandcpp::logging::set_log_to_console(false);
+    wujihandcpp::logging::set_log_level(wujihandcpp::logging::Level::OFF);
+    constexpr auto index = wujihandcpp::data::joint::TargetPosition::index;
+    return index == 0x7A ? 0 : 1;
+}
+CPP
+cmake -S "${consumer_dir}" -B "${consumer_dir}/build"
+cmake --build "${consumer_dir}/build" --parallel 2
+"${consumer_dir}/build/wujihandcpp_deb_consumer"
+
+rosdep init 2>/dev/null || true
+rosdep update --rosdistro "${ROS_DISTRO}"
+
+workspace="$(mktemp -d)"
+mkdir -p "${workspace}/src"
+git clone --recurse-submodules --depth 1 \
+  "${WUJIHANDROS2_REPO:-https://github.com/wuji-technology/wujihandros2.git}" \
+  "${workspace}/src/wujihandros2"
+
+cd "${workspace}"
+rosdep install \
+  --from-paths src \
+  --ignore-src \
+  --rosdistro "${ROS_DISTRO}" \
+  --skip-keys wujihandcpp \
+  -r -y
+
+# shellcheck disable=SC1090
+. "/opt/ros/${ROS_DISTRO}/setup.bash"
+colcon build --event-handlers console_direct+

--- a/tests/test_ci_ros2_downstream_workflow.py
+++ b/tests/test_ci_ros2_downstream_workflow.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "deb-downstream-ros2.yml"
+SCRIPT = ROOT / "ci" / "check_wujihandros2_downstream.sh"
+
+
+def test_ros2_downstream_workflow_targets_lts_matrix():
+    text = WORKFLOW.read_text()
+
+    assert "ros:humble-ros-base" in text
+    assert 'ubuntu: "22.04"' in text
+    assert "ros:jazzy-ros-base" in text
+    assert 'ubuntu: "24.04"' in text
+    assert "ros:lyrical-ros-base" in text
+    assert 'ubuntu: "26.04"' in text
+    assert "kilted" not in text
+
+
+def test_ros2_downstream_workflow_uses_shared_script_and_deb_artifact():
+    text = WORKFLOW.read_text()
+
+    assert "pull_request:" in text
+    assert "Dockerfile.package-builder" in text
+    assert "actions/upload-artifact" in text
+    assert "actions/download-artifact" in text
+    assert "./ci/check_wujihandros2_downstream.sh" in text
+
+
+def test_ros2_downstream_script_documents_downstream_build_steps():
+    text = SCRIPT.read_text()
+
+    assert "apt-get install -y" in text
+    assert "dpkg -s wujihandcpp" in text
+    assert "find_package(wujihandcpp CONFIG REQUIRED)" in text
+    assert "git clone --recurse-submodules --depth 1" in text
+    assert "wujihandros2" in text
+    assert "rosdep install" in text
+    assert "colcon build" in text


### PR DESCRIPTION
## Summary
- Build the wujihandcpp deb once with the existing Dockerfile.package-builder.
- Install the generated deb in ROS 2 LTS Docker environments: Humble/Ubuntu 22.04, Jazzy/Ubuntu 24.04, and Lyrical/Ubuntu 26.04.
- Clone wujihandros2, run rosdep with wujihandcpp skipped, and run colcon build to catch broken deb exports or missing downstream dependencies on every PR.

## Validation
- python3 -m pytest tests/test_ci_ros2_downstream_workflow.py -q
- bash -n ci/check_wujihandros2_downstream.sh
- shellcheck ci/check_wujihandros2_downstream.sh
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:latest .github/workflows/deb-downstream-ros2.yml
- git diff --check

## Notes
- Full local `python3 -m pytest tests -q` was not run successfully because this clean worktree does not have `wujihandpy` installed, so existing tests that import `wujihandpy` fail during collection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 新增 ROS 2 下游集成验证流程，支持 Humble、Jazzy 和 Lyrical 等 LTS 发行版本。
  * 自动验证 Debian 包的质量、依赖解析和下游构建兼容性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wuji-technology/wujihandpy/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->