### PR TITLE
docs: 补充 Hand(side='left'/'right') 构造器说明（跟进 #83）

### DIFF
--- a/docs/external/en/api-reference.mdx
+++ b/docs/external/en/api-reference.mdx
@@ -188,7 +188,7 @@ This field records the lower position limit of the joint.
 ### 2.1 Hand Class
 
 #### 2.1.1 Constructor
-- `__init__(serial_number=None, *, side=None, usb_pid=-1, usb_vid=1155, mask=None) -> None`
+- `__init__(serial_number=None, *, side=None, usb_pid=0x2000, usb_vid=0x0483, mask=None) -> None`
   *Initialize connection to the dexterous hand. Supports specifying the device by serial number, handedness, USB ID, or device mask.*
 
   - `serial_number`: USB serial number string to select one device exactly

--- a/docs/external/en/api-reference.mdx
+++ b/docs/external/en/api-reference.mdx
@@ -188,8 +188,11 @@ This field records the lower position limit of the joint.
 ### 2.1 Hand Class
 
 #### 2.1.1 Constructor
-- `__init__(serial_number=None, usb_pid=-1, usb_vid=1155, mask=None) -> None`
-  *Initialize connection to the dexterous hand, supports specifying device via serial number, USB ID, or device mask*
+- `__init__(serial_number=None, *, side=None, usb_pid=-1, usb_vid=1155, mask=None) -> None`
+  *Initialize connection to the dexterous hand. Supports specifying the device by serial number, handedness, USB ID, or device mask.*
+
+  - `serial_number`: USB serial number string to select one device exactly
+  - `side`: `"left"` or `"right"`. Selects the device by handedness. Mutually exclusive with `serial_number` (see [Tutorial §1.3](./tutorial#1-3-filtering-devices))
 
 #### 2.1.2 Finger Access
 - `finger(index) -> Finger`

--- a/docs/external/en/tutorial.mdx
+++ b/docs/external/en/tutorial.mdx
@@ -9,7 +9,13 @@ This section describes how to connect to dexterous hand devices in wujihandpy an
 ### 1.1 Interface Overview
 ```python
 class Hand:
-    def __init__(self, serial_number: str | None = None, ...) -> None:
+    def __init__(
+        self,
+        serial_number: str | None = None,
+        *,
+        side: str | None = None,
+        ...,
+    ) -> None:
         ...
 ```
 
@@ -33,11 +39,32 @@ Traceback (most recent call last):
            ^^^^^^^^^^^^^^^^^
 RuntimeError: Failed to init.
 ```
-To resolve this issue, you can explicitly specify the device to connect to using the `serial_number` parameter:
+There are two ways to specify which device to connect to.
+
+#### Select by serial number
+Pass the `serial_number` parameter to identify the device explicitly:
 ```python
 hand = wujihandpy.Hand(serial_number="337238793233")
 ```
 This ensures that the program always connects to the correct device instance.
+
+#### Select by handedness
+When the system has exactly one left hand and one right hand connected, the `side` parameter selects the device directly, without needing to remember any serial number:
+```python
+left = wujihandpy.Hand(side="left")
+right = wujihandpy.Hand(side="right")
+```
+The SDK enumerates all matching devices, reads the handedness identifier from each, and connects to the matching one.
+
+<Callout type="info">
+**`side` and `serial_number` are mutually exclusive**
+
+Pass only one of them. Passing both raises `ValueError`. `side` accepts only the string `"left"` or `"right"`. Any other value raises `ValueError`.
+
+Common failure cases:
+- No hand of the requested side is connected → raises `ConnectionError` with `No <side> hand found`
+- Two hands of the same side are connected → raises `ConnectionError` suggesting `serial_number` instead
+</Callout>
 
 ### 1.4 Querying Serial Numbers
 
@@ -376,7 +403,7 @@ When calling asynchronous interfaces, use `await`. The event loop is not blocked
 <Callout type="warning">
   **Latency Characteristics of Non-Real-Time Interfaces**
 
-  Asynchronous requests also require 5~10 ms to complete. They are not inherently faster; they simply do not block the event loop.
+  Asynchronous requests also require 5~10 ms to complete. They are not inherently faster. They simply do not block the event loop.
 
   Compared to synchronous interfaces, the only difference with asynchronous interfaces is that they allow other coroutine tasks to execute during the wait.
   Therefore, do not call these APIs in real-time control loops or high-frequency loops requiring high real-time performance.

--- a/docs/external/zh/api-reference.mdx
+++ b/docs/external/zh/api-reference.mdx
@@ -188,7 +188,7 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 ### 2.1 Hand 类
 
 #### 2.1.1 构造函数
-- `__init__(serial_number=None, *, side=None, usb_pid=-1, usb_vid=1155, mask=None) -> None`
+- `__init__(serial_number=None, *, side=None, usb_pid=0x2000, usb_vid=0x0483, mask=None) -> None`
   *初始化灵巧手连接，支持通过序列号、左右手、USB ID 或设备掩码指定设备*
 
   - `serial_number`：USB 序列号字符串，精确指定一台设备

--- a/docs/external/zh/api-reference.mdx
+++ b/docs/external/zh/api-reference.mdx
@@ -188,8 +188,11 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 ### 2.1 Hand 类
 
 #### 2.1.1 构造函数
-- `__init__(serial_number=None, usb_pid=-1, usb_vid=1155, mask=None) -> None`
-  *初始化灵巧手连接，支持通过序列号、USB ID 或设备掩码指定设备*
+- `__init__(serial_number=None, *, side=None, usb_pid=-1, usb_vid=1155, mask=None) -> None`
+  *初始化灵巧手连接，支持通过序列号、左右手、USB ID 或设备掩码指定设备*
+
+  - `serial_number`：USB 序列号字符串，精确指定一台设备
+  - `side`：`"left"` 或 `"right"`，按手性选择设备，与 `serial_number` 互斥（详见 [教程 §1.3](./tutorial#1-3-筛选设备)）
 
 #### 2.1.2 手指访问
 - `finger(index) -> Finger`

--- a/docs/external/zh/tutorial.mdx
+++ b/docs/external/zh/tutorial.mdx
@@ -9,7 +9,13 @@ description: Wuji Hand SDK (wujihandpy) 教程，涵盖设备连接、同步/异
 ### 1.1 接口概述
 ```python
 class Hand:
-    def __init__(self, serial_number: str | None = None, ...) -> None:
+    def __init__(
+        self,
+        serial_number: str | None = None,
+        *,
+        side: str | None = None,
+        ...,
+    ) -> None:
         ...
 ```
 
@@ -33,11 +39,32 @@ Traceback (most recent call last):
            ^^^^^^^^^^^^^^^^^
 RuntimeError: Failed to init.
 ```
-为解决该问题，可通过 `serial_number` 参数明确指定要连接的设备：
+为解决该问题，有两种方式指定要连接的设备。
+
+#### 按序列号指定
+通过 `serial_number` 参数明确指定设备：
 ```python
 hand = wujihandpy.Hand(serial_number="337238793233")
 ```
 这样可确保程序始终连接到正确的设备实例。
+
+#### 按左右手指定
+当系统中恰好连接一只左手和一只右手时，可直接用 `side` 参数选择，无需记忆序列号：
+```python
+left = wujihandpy.Hand(side="left")
+right = wujihandpy.Hand(side="right")
+```
+SDK 会自动枚举所有匹配设备、读取每只手的手性标识，再连接对应一只。
+
+<Callout type="info">
+**`side` 与 `serial_number` 互斥**
+
+两者只能选一个传入。同时指定会抛 `ValueError`。`side` 仅接受字符串 `"left"` 或 `"right"`，其他取值会抛 `ValueError`。
+
+匹配失败的常见情形：
+- 没插对应侧的手 → 抛 `ConnectionError`，提示 `No <side> hand found`
+- 同侧插了两只 → 抛 `ConnectionError`，提示改用 `serial_number`
+</Callout>
 
 ### 1.4 查询序列号
 


### PR DESCRIPTION
## Summary

跟进已合入的 PR #83 (feat: Hand(side='left'/'right') constructor for handedness-based device selection)，对外文档补 `side` 关键字参数：

- 教程 §1.3 拆"按序列号 / 按左右手"两个子节，给出 `Hand(side=\"left\")` / `Hand(side=\"right\")` 示例和互斥/异常说明
- 教程 §1.1 接口概述签名加 `side` keyword-only 参数
- API 参考 §2.1.1 Hand 构造函数签名加 `side` 参数及参数说明，并交叉链接到教程 §1.3
- 顺手把英文教程 §5 一处遗留的"分号"违规拆成两句

中英双语对称修改。

## Test plan

- [x] 写作规范：Microsoft Writing Style Guide，正文无分号（中英文双向 grep 已确认）
- [x] 链接：新增锚点 `#1-3-筛选设备` / `#1-3-filtering-devices` 均能解析到真实的 `### 1.3` 标题
- [x] 源码核对（`/source-check --incremental --pr`）：所有新增声明（`side` 关键字参数、与 `serial_number` 互斥、`"left"/"right"` 字面量、`ValueError` 异常、`ConnectionError` "No <side> hand found" / "use serial_number" 提示文本、`Hand.Side.Left=1/Right=0` enum）与 `src/wujihandpy/__init__.py`、`wujihandcpp/include/wujihandcpp/device/hand.hpp` 完全一致
- [x] 中英文一致性：子节标题层级、Callout 类型、列表项数量、代码示例平行
- [x] 三路本地 review（pr-review-toolkit）通过
- [x] 仅改 `docs/external/`，未触及代码与其他公开面文件

跟进 #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 更新 Hand 类构造函数说明，新增可通过 side（"left"/"right"）按左右手选择设备的描述。
  * 明确 side 与 serial_number 互斥、无效参数及同时指定时会触发错误的行为说明。
  * 同步更新中英文教程与 API 参考中的示例与设备选择指引，并补充常见连接失败场景提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->