### PR TITLE
docs: 修正 §7.3 close() 断连行为描述

### DIFF
--- a/docs/external/en/tutorial.mdx
+++ b/docs/external/en/tutorial.mdx
@@ -376,7 +376,7 @@ When calling asynchronous interfaces, use `await`. The event loop is not blocked
 <Callout type="warning">
   **Latency Characteristics of Non-Real-Time Interfaces**
 
-  Asynchronous requests also require 5~10 ms to complete. They are not inherently faster; they simply do not block the event loop.
+  Asynchronous requests also require 5~10 ms to complete. They are not inherently faster. They simply do not block the event loop.
 
   Compared to synchronous interfaces, the only difference with asynchronous interfaces is that they allow other coroutine tasks to execute during the wait.
   Therefore, do not call these APIs in real-time control loops or high-frequency loops requiring high real-time performance.
@@ -589,7 +589,16 @@ Run the script, then unplug the USB cable while it reads. The loop is interrupte
 
 Real-time control loops rely on high-speed PDO data. On disconnect, these interfaces simply stop updating the cache instead of raising an exception. To detect a disconnect in real-time scenarios, periodically call a synchronous read (such as `read_input_voltage()`) as a probe in a low-speed bypass loop, and catch `ConnectionError`.
 
-When the real-time controller is used as a context manager, the end of the `with` block automatically calls `close()` to clean up. `close()` also returns safely on disconnect, so no extra handling is needed.
+When the real-time controller is used as a context manager, the end of the `with` block automatically calls `close()` to clean up. If a disconnect happens during the `with` block, `close()` raises `ConnectionError`. Wrap the `with` block in `try`/`except` to handle it:
+
+```python
+try:
+    with hand.realtime_controller(...) as ctrl:
+        # real-time control loop
+        ...
+except ConnectionError as e:
+    print(f"Disconnect detected: {e}")
+```
 
 ### 7.4 More Examples
 - [example/joint/6.disconnect.py](https://github.com/wuji-technology/wujihandpy/blob/main/example/joint/6.disconnect.py)

--- a/docs/external/zh/tutorial.mdx
+++ b/docs/external/zh/tutorial.mdx
@@ -588,7 +588,16 @@ if __name__ == "__main__":
 
 实时控制环路依赖 PDO 高速数据，断连时这些接口仅停止更新缓存，不抛出异常。若需在实时控制场景中检测断连，请在旁路低速循环中周期性调用一次同步读取（如 `read_input_voltage()`）作为探测，并捕获 `ConnectionError`。
 
-实时控制器以上下文管理器使用时，`with` 块结束会自动调用 `close()` 完成清理。断连状态下 `close()` 也会安全返回，无需额外处理。
+实时控制器以上下文管理器使用时，`with` 块结束会自动调用 `close()` 完成清理。若 `with` 块运行期间发生断连，`close()` 会抛出 `ConnectionError`，建议在 `with` 外层加 `try`/`except` 捕获：
+
+```python
+try:
+    with hand.realtime_controller(...) as ctrl:
+        # 实时控制循环
+        ...
+except ConnectionError as e:
+    print(f"Disconnect detected: {e}")
+```
 
 ### 7.4 更多示例
 - [example/joint/6.disconnect.py](https://github.com/wuji-technology/wujihandpy/blob/main/example/joint/6.disconnect.py)


### PR DESCRIPTION
## Summary

- 修正 `docs/external/{zh,en}/tutorial.mdx` §7.3 末段对 `close()` 断连行为的错误描述：旧文档称"断连状态下 `close()` 也会安全返回"，与代码实际行为不符（`__exit__` → `IControllerWrapper::close()` → `detach()` 链路上 `ConnectionError` 会逐层 re-throw）
- 改为说明 `with` 块期间断连会抛出 `ConnectionError`，并补充 `try`/`except` 捕获示例
- 顺手修复英文版 §7.2 Callout 中一处遗留分号（拆成两句）

## Test plan

- [x] 对照源码确认描述准确：`src/main.cpp:63-65` → `src/controller.hpp:74-83` → `wujihandcpp/include/wujihandcpp/device/hand.hpp:417-428`
- [x] 中英文 §7.3 结构、代码块、段落顺序一致
- [x] 通过 no-semicolons-in-docs hook 校验
- [x] pr-review-toolkit 本地审查通过

Resolve f-7002128133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **文档**
  * 更新教程中的异步接口说明，明确表述请求完成时间，强调不会阻塞事件循环
  * 新增实时控制模式下的断连异常处理说明，包含捕获连接错误的示例代码

<!-- end of auto-generated comment: release notes by coderabbit.ai -->