### PR TITLE
docs: 清理 wuji-hand-description 旧仓名引用并修复失效文档链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Wuji Hand SDK: C++ core with Python bindings, for controlling and communicating with Wuji Hand. WujihandPy is the Python binding of [WujihandCpp](wujihandcpp/README.md), providing an easy-to-use Python API for Wujihand dexterous-hand devices. Supports synchronous, asynchronous, unchecked operations and real-time control.
 
-**Get started with [Quick Start](#quick-start). For detailed documentation, please refer to [SDK Tutorial](https://docs.wuji.tech/docs/en/wuji-hand/latest/sdk-user-guide/introduction) on Wuji Docs Center.**
+**Get started with [Quick Start](#quick-start). For detailed documentation, please refer to [SDK Tutorial](https://docs.wuji.tech/docs/en/wujihandpy/latest/tutorial/) on Wuji Docs Center.**
 
 ## Repository Structure
 
@@ -82,8 +82,8 @@ For scenarios that require smooth joint position control, be sure to use `realti
 
 ### References
 
-- **Documentation**: [Quick Start](https://docs.wuji.tech/docs/en/wuji-hand/latest/sdk-user-guide/introduction/)
-- **API Reference**: [API Reference](https://docs.wuji.tech/docs/en/wuji-hand/latest/sdk-user-guide/api-reference/)
+- **Documentation**: [Introduction](https://docs.wuji.tech/docs/en/wujihandpy/latest/introduction/)
+- **API Reference**: [API Reference](https://docs.wuji.tech/docs/en/wujihandpy/latest/api-reference/)
 - **CI Workflows**: [workflow overview](docs/ci-workflows.md)
 - **Package CI**: [wujihandcpp deb smoke gate](docs/wujihandcpp-deb-smoke-gate.md)
 - **URDF Files**: [wuji-description](https://github.com/wuji-technology/wuji-description)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For scenarios that require smooth joint position control, be sure to use `realti
 - **API Reference**: [API Reference](https://docs.wuji.tech/docs/en/wuji-hand/latest/sdk-user-guide/api-reference/)
 - **CI Workflows**: [workflow overview](docs/ci-workflows.md)
 - **Package CI**: [wujihandcpp deb smoke gate](docs/wujihandcpp-deb-smoke-gate.md)
-- **URDF Files**: [wuji-hand-description](https://github.com/wuji-technology/wuji-hand-description)
+- **URDF Files**: [wuji-description](https://github.com/wuji-technology/wuji-description)
 
 ## Contact
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -130,7 +130,7 @@ finally:
 
 | Path | Type / Schema title | Description |
 |------|---------------------|-------------|
-| `joint_states` | `sensor_msgs/JointState` — `{name: string[20], position: number[20]}` | Flat row-major projection of `joint/actual_position`. Joint names follow `{side}_finger{1..5}_joint{1..4}`, matching [`wuji-hand-description`](https://github.com/wuji-technology/wuji-hand-description) URDFs. **Published without the timestamp envelope** so downstream consumers (e.g. Wuji Studio's 3D panel) can identify it directly by schema title and drive a URDF visualization. |
+| `joint_states` | `sensor_msgs/JointState` — `{name: string[20], position: number[20]}` | Flat row-major projection of `joint/actual_position`. Joint names follow `{side}_finger{1..5}_joint{1..4}`, matching [`wuji-description`](https://github.com/wuji-technology/wuji-description) URDFs. **Published without the timestamp envelope** so downstream consumers (e.g. Wuji Studio's 3D panel) can identify it directly by schema title and drive a URDF visualization. |
 
 ### SET Resources
 
@@ -172,7 +172,7 @@ touching the control path:
    `/wuji/{sn}/joint_states` becomes subscribable (schema
    `sensor_msgs/JointState`).
 2. Open a **3D** panel → **Add URDF** → source **filePath** → point to
-   `wuji-hand-description/urdf/left.urdf` (or `right.urdf` — must match the
+   `wuji-description/hand/body/urdf/left.urdf` (or `right.urdf` — must match the
    `--side` you launched the bridge with).
 3. The 3D panel auto-subscribes `joint_states` and animates the URDF.
 

--- a/bridge/python/hand_zenoh_bridge.py
+++ b/bridge/python/hand_zenoh_bridge.py
@@ -47,7 +47,7 @@ def sanitize_sn(sn: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Joint naming (matches wuji-hand-description URDF)
+# Joint naming (matches wuji-description URDF)
 # ---------------------------------------------------------------------------
 
 # Resources that stream raw values without the {timestamp_us, data} envelope.
@@ -57,7 +57,7 @@ _ENVELOPE_EXEMPT_PATHS = frozenset({"joint_states"})
 
 
 def make_joint_names(side: str) -> list:
-    """Build 20 joint names matching `wuji-hand-description/urdf/{side}.urdf`.
+    """Build 20 joint names matching `wuji-description/hand/body/urdf/{side}.urdf`.
 
     Row-major flatten order of the 5x4 joint array:
         name[i * 4 + j] = f"{side}_finger{i+1}_joint{j+1}"


### PR DESCRIPTION
## Summary

- description 仓库已更名为 wuji-description，模型资产按 hand/ 与 glove/ 重新组织。更新 README、bridge/README 中的仓库链接，以及 bridge 代码注释中的 URDF 路径（hand/body/urdf/{side}.urdf，已核实新仓该文件存在）
- README 中 3 个指向已下线 sdk-user-guide 页面的链接（404）改指 wujihandpy 产品现行文档页（tutorial / introduction / api-reference）
- CHANGELOG 中的旧仓名引用为历史发布记录，保持不动
- hand_zenoh_bridge.py 仅改注释与 docstring，无任何功能变更

## 自测结果

- 自测环境：WSL2 (Linux 6.6)，curl 带浏览器 UA 验证
- 3 个新文档链接（wujihandpy/latest 下 tutorial、introduction、api-reference）均返回 200
- wuji-description 仓库链接返回 200，URDF 路径 hand/body/urdf/left.urdf、right.urdf 经 GitHub API 确认存在
- 变更文件全部外链与内部锚点逐一复检，均有效
- 本地 review 确认 .py 文件 diff 仅含注释行，运行逻辑零变更

🤖 Generated with [Claude Code](https://claude.com/claude-code)