### PR TITLE
fix(transport): break event loop on stop request to unblock shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `wujihand_zenoh_bridge` hanging after Ctrl+C. The USB event loop's `handle_events()` only checked `active_transfers_`, so during shutdown with in-flight libusb transfers the event thread never exited and `~Usb` blocked on `event_thread_.join()`, leaving the process stuck after logging "Bridge stopped". The loop now also checks `stop_handling_events_` so the destructor completes cleanly.
+
 ## [1.8.0] - 2026-06-10
 
 ### Added

--- a/wujihandcpp/src/transport/usb.cpp
+++ b/wujihandcpp/src/transport/usb.cpp
@@ -437,7 +437,8 @@ private:
     }
 
     void handle_events() {
-        while (active_transfers_.load(std::memory_order::relaxed)) {
+        while (!stop_handling_events_.load(std::memory_order::relaxed) &&
+               active_transfers_.load(std::memory_order::relaxed)) {
             libusb_handle_events(libusb_context_);
         }
     }


### PR DESCRIPTION
## 背景

`./wujihand_zenoh_bridge --pub-rate 1000` 在 Ctrl+C 后打印 `Bridge stopped` 仍不退出，进程卡死。

## 根因

`Usb::handle_events()` 事件循环条件仅依赖 `active_transfers_`：

```cpp
while (active_transfers_.load(std::memory_order::relaxed)) {
    libusb_handle_events(libusb_context_);
}
```

`~Usb` 析构阶段先置 `stop_handling_events_ = true`，再 `libusb_close` 取消 pending transfer。但若 `libusb_handle_events` 仍阻塞且 `active_transfers_` 未归零，循环不退出，`event_thread_.join()` 卡死，整个析构链条走不完——表现就是 "Bridge stopped" 之后挂起。

## 修复

循环条件加 `!stop_handling_events_` 早退检查：

```cpp
while (!stop_handling_events_.load(std::memory_order::relaxed) &&
       active_transfers_.load(std::memory_order::relaxed)) {
    libusb_handle_events(libusb_context_);
}
```

事件线程在析构早期即可退出，析构链条能走完。

## 验证

- worktree 本地构建 green（Ninja RelWithDebInfo，仅 pre-existing `CurrentLimit` 弃用警告）
- 真机 Ctrl+C 行为已由 @Blackjack200 在硬件上验证干净退出

关联工作项：[m-7048289564](https://project.feishu.cn/uts5wn/bug/detail/7048289564)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 Ctrl+C 后可能卡住的问题：USB 事件处理循环在收到停止信号时可更快退出。
  * 改进停止与关闭时的稳定性，确保事件处理线程能及时停止，避免析构阶段阻塞延迟结束。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->