### PR TITLE
ci: scope app token to docs center and JSON-encode dispatch payload

### DIFF
--- a/.github/workflows/docs-notify.yml
+++ b/.github/workflows/docs-notify.yml
@@ -37,7 +37,7 @@ jobs:
           app-id: ${{ env.AUTOMATION_APP_ID }}
           private-key: ${{ env.AUTOMATION_APP_PRIVATE_KEY }}
           owner: wuji-technology
-
+          repositories: wuji-docs-center
       - name: Notify docs preview
         if: steps.automation-config.outputs.configured == 'true' && github.event_name == 'pull_request'
         uses: peter-evans/repository-dispatch@v4
@@ -47,10 +47,10 @@ jobs:
           event-type: docs-preview
           client-payload: |
             {
-              "repo": "${{ github.event.repository.name }}",
-              "branch": "${{ github.head_ref }}",
-              "pr_number": "${{ github.event.pull_request.number }}",
-              "sha": "${{ github.event.pull_request.head.sha }}"
+              "repo": ${{ toJSON(github.event.repository.name) }},
+              "branch": ${{ toJSON(github.head_ref) }},
+              "pr_number": ${{ toJSON(github.event.pull_request.number) }},
+              "sha": ${{ toJSON(github.event.pull_request.head.sha) }}
             }
 
       - name: Notify docs publish
@@ -63,5 +63,5 @@ jobs:
           client-payload: |
             {
               "repo": "wujihandpy",
-              "sha": "${{ github.sha }}"
+              "sha": ${{ toJSON(github.sha) }}
             }


### PR DESCRIPTION
Scope the GitHub App token to the dispatch target repository instead of the whole installation, and wrap dynamic client-payload fields in toJSON so branch names with special characters cannot produce invalid JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 优化文档预览与发布通知流程，提升事件数据传递的准确性与稳定性。
  * 收紧自动化访问范围，增强相关流程的安全性与可控性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->