### PR TITLE
ci: harden docs workflows for fork PR context

### DIFF
--- a/.github/workflows/docs-followup.yml
+++ b/.github/workflows/docs-followup.yml
@@ -25,7 +25,13 @@ name: Post-Merge Docs Follow-up
 #   - .github/scripts/docs-followup/*.sh
 
 on:
-  pull_request:
+  # pull_request_target (not pull_request): fork PRs get no secrets and a
+  # read-only GITHUB_TOKEN under pull_request, which would break labeling,
+  # PR comments, and the Feishu DM for merged fork PRs. All jobs check out
+  # and execute scripts from the BASE repo only (actions/checkout default
+  # under pull_request_target — no ref: override), never PR head code, so
+  # this is safe.
+  pull_request_target:
     types: [closed]
     branches: [main]
 

--- a/.github/workflows/docs-notify.yml
+++ b/.github/workflows/docs-notify.yml
@@ -1,11 +1,12 @@
 name: "Docs: Notify Docs Center"
 
-env:
-  AUTOMATION_APP_ID: ${{ vars.AUTOMATION_APP_ID }}
-  AUTOMATION_APP_PRIVATE_KEY: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
-
 on:
-  pull_request:
+  # pull_request_target (not pull_request): fork PRs get no secrets and a
+  # read-only token under pull_request, which would silently disable the App
+  # token generation and cross-repo dispatch. This workflow never checks out
+  # or executes PR head code — it only reads event metadata — so the elevated
+  # context is safe.
+  pull_request_target:
     types: [opened, synchronize, reopened]
     paths:
       - 'docs/external/**'
@@ -21,6 +22,11 @@ jobs:
     steps:
       - name: Check automation app config
         id: automation-config
+        # Secrets are scoped to the steps that need them instead of a
+        # workflow-level env, so third-party actions never see the App key.
+        env:
+          AUTOMATION_APP_ID: ${{ vars.AUTOMATION_APP_ID }}
+          AUTOMATION_APP_PRIVATE_KEY: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
         run: |
           if [[ -n "${AUTOMATION_APP_ID}" && -n "${AUTOMATION_APP_PRIVATE_KEY}" ]]; then
             echo "configured=true" >> "$GITHUB_OUTPUT"
@@ -34,12 +40,15 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ env.AUTOMATION_APP_ID }}
-          private-key: ${{ env.AUTOMATION_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: wuji-technology
           repositories: wuji-docs-center
+          # repository_dispatch only needs contents: write — don't inherit
+          # the installation's full permission set.
+          permission-contents: write
       - name: Notify docs preview
-        if: steps.automation-config.outputs.configured == 'true' && github.event_name == 'pull_request'
+        if: steps.automation-config.outputs.configured == 'true' && github.event_name == 'pull_request_target'
         uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -62,6 +71,6 @@ jobs:
           event-type: docs-updated
           client-payload: |
             {
-              "repo": "wujihandpy",
+              "repo": ${{ toJSON(github.event.repository.name) }},
               "sha": ${{ toJSON(github.sha) }}
             }

--- a/.github/workflows/docs-prerelease-sync.yml
+++ b/.github/workflows/docs-prerelease-sync.yml
@@ -1,6 +1,4 @@
-# 源仓保鲜 workflow 模板：main 上 docs/external/ 有 push 时自动 merge 进 docs-prerelease。
-# 由 scripts/rollout-docs-prerelease.sh 铺开到各源仓的 .github/workflows/ 下。
-# 注意：默认分支为 master 的仓库（如 wh110-firmware），rollout 脚本会替换 branches 触发项。
+# 源仓保鲜 workflow：main 上 docs/external/ 有 push 时自动 merge 进 docs-prerelease。
 name: Sync default branch into docs-prerelease
 
 on:


### PR DESCRIPTION
## 变更内容

三处 docs workflow 安全加固，修复 fork PR 场景失效：

- **触发器改 `pull_request_target`**（`docs-followup.yml` + `docs-notify.yml`）：本仓绝大多数合入 PR 来自 fork。fork PR 在 `pull_request` 下拿到只读 token 且无 secrets，导致打 `docs:followup` 标签、PR 评论、文档中心通知全部静默失效。改后 fork PR 也能拿到写权限与 secrets。各 job 的 checkout 均取 base 仓（无 `ref:` 覆盖），不执行 PR head 代码，无 RCE 面。
- **App 凭据收敛到 step 级**（`docs-notify.yml`）：不再挂 workflow 级 `env`，避免第三方 action 见到 App key。
- **App token 最小权限**（`docs-notify.yml`）：`repository_dispatch` 只需 `contents: write`，显式限定不继承安装全部权限。
- **脱敏**（`docs-prerelease-sync.yml`）：去掉头注释里的私有仓名。

## 背景

本仓 docs workflow 从共享模板 rollout。同族公开仓 wuji-mjlab 已先行加固（wuji-technology/wuji-mjlab#8），本 PR 与 wujihandros2 对齐同一套修复。

## 自测结果

- 3 个 workflow YAML 解析通过
- 查证本仓 docs-followup 历史从未成功打过 `docs:followup` 标签（fork PR 失效实锤）
- checkout 步骤全部无 `ref:` 覆盖，`pull_request_target` 下取 base 仓，安全

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化文档相关自动化流程在跨仓库及权限场景下的触发与通知机制。
  * 增强敏感凭据的按需使用，降低不必要的暴露范围。
  * 文档更新通知现可根据事件来源动态识别仓库。
* **文档**
  * 更新文档预发布同步流程的说明，使其与实际行为保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->