### PR TITLE
docs: 修复 api-reference 指向教程的相对链接（2 处）

### DIFF
--- a/docs/external/en/api-reference.mdx
+++ b/docs/external/en/api-reference.mdx
@@ -192,7 +192,7 @@ This field records the lower position limit of the joint.
   *Initialize connection to the dexterous hand. Supports specifying the device by serial number, handedness, USB ID, or device mask.*
 
   - `serial_number`: USB serial number string to select one device exactly
-  - `side`: `"left"` or `"right"`. Selects the device by handedness. Mutually exclusive with `serial_number` (see [Tutorial §1.3](./tutorial#1-3-filtering-devices))
+  - `side`: `"left"` or `"right"`. Selects the device by handedness. Mutually exclusive with `serial_number` (see [Tutorial §1.3](../tutorial#1-3-filtering-devices))
 
 #### 2.1.2 Finger Access
 - `finger(index) -> Finger`

--- a/docs/external/zh/api-reference.mdx
+++ b/docs/external/zh/api-reference.mdx
@@ -192,7 +192,7 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
   *初始化灵巧手连接，支持通过序列号、左右手、USB ID 或设备掩码指定设备*
 
   - `serial_number`：USB 序列号字符串，精确指定一台设备
-  - `side`：`"left"` 或 `"right"`，按手性选择设备，与 `serial_number` 互斥（详见 [教程 §1.3](./tutorial#1-3-筛选设备)）
+  - `side`：`"left"` 或 `"right"`，按手性选择设备，与 `serial_number` 互斥（详见 [教程 §1.3](../tutorial#1-3-筛选设备)）
 
 #### 2.1.2 手指访问
 - `finger(index) -> Finger`


### PR DESCRIPTION
## Summary

- api-reference（zh/en）里 `./tutorial#…` 相对链接在文档站目录式路由下解析到当前页子路径（404），改为 `../tutorial#…`

## Test plan

- 文档站路由语义核对：非 index 页面的同目录兄弟页需用 `../` 前缀

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 修正中英文 API 参考文档中的教程链接，确保“筛选设备”相关链接可正常访问。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->