### PR TITLE
docs(api-reference): 修正教程 §1.3 的锚点链接

### DIFF
--- a/docs/external/en/api-reference.mdx
+++ b/docs/external/en/api-reference.mdx
@@ -192,7 +192,7 @@ This field records the lower position limit of the joint.
   *Initialize connection to the dexterous hand. Supports specifying the device by serial number, handedness, USB ID, or device mask.*
 
   - `serial_number`: USB serial number string to select one device exactly
-  - `side`: `"left"` or `"right"`. Selects the device by handedness. Mutually exclusive with `serial_number` (see [Tutorial §1.3](../tutorial#1-3-filtering-devices))
+  - `side`: `"left"` or `"right"`. Selects the device by handedness. Mutually exclusive with `serial_number` (see [Tutorial §1.3](../tutorial#13-filtering-devices))
 
 #### 2.1.2 Finger Access
 - `finger(index) -> Finger`

--- a/docs/external/zh/api-reference.mdx
+++ b/docs/external/zh/api-reference.mdx
@@ -192,7 +192,7 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
   *初始化灵巧手连接，支持通过序列号、左右手、USB ID 或设备掩码指定设备*
 
   - `serial_number`：USB 序列号字符串，精确指定一台设备
-  - `side`：`"left"` 或 `"right"`，按手性选择设备，与 `serial_number` 互斥（详见 [教程 §1.3](../tutorial#1-3-筛选设备)）
+  - `side`：`"left"` 或 `"right"`，按手性选择设备，与 `serial_number` 互斥（详见 [教程 §1.3](../tutorial#13-筛选设备)）
 
 #### 2.1.2 手指访问
 - `finger(index) -> Finger`


### PR DESCRIPTION
## Summary

`api-reference` 中指向教程「1.3 筛选设备」小节的锚点链接失效，点击后停留在页面顶部。

标题 `### 1.3 筛选设备` 生成的锚点 id 是 `13-筛选设备`（点号被删除，而非转为连字符），原链接写作 `#1-3-筛选设备`，前缀多了一个连字符。英文页同样问题。

- 中文：`../tutorial#1-3-筛选设备` → `../tutorial#13-筛选设备`
- 英文：`../tutorial#1-3-filtering-devices` → `../tutorial#13-filtering-devices`

## 自测

- 目标锚点已按线上渲染结果核实（文档站教程页实际 id 为 `13-筛选设备` / `13-filtering-devices`）
- 全仓扫描无其他同类失效锚点

🤖 Generated with [Claude Code](https://claude.com/claude-code)