### PR TITLE
docs(style): 清除教程连接说明的口语化表述

### DIFF
--- a/docs/external/zh/tutorial.mdx
+++ b/docs/external/zh/tutorial.mdx
@@ -62,8 +62,8 @@ SDK 会自动枚举所有匹配设备、读取每只手的手性标识，再连�
 两者只能选一个传入。同时指定会抛 `ValueError`。`side` 仅接受字符串 `"left"` 或 `"right"`，其他取值会抛 `ValueError`。
 
 匹配失败的常见情形：
-- 没插对应侧的手 → 抛 `ConnectionError`，提示 `No <side> hand found`
-- 同侧插了两只 → 抛 `ConnectionError`，提示改用 `serial_number`
+- 未接入对应侧的手 → 抛 `ConnectionError`，提示 `No <side> hand found`
+- 同侧接入了两只 → 抛 `ConnectionError`，提示改用 `serial_number`
 </Callout>
 
 ### 1.4 查询序列号


### PR DESCRIPTION
## Summary

清除中文文档正文的口语化表述（全站口语化清理·高严重度批），仅措辞调整，不改技术语义、代码块、链接与标题锚点。

## Test plan

- 逐句人工核对改写前后语义一致
- grep 自查：改动行无分号、无第二人称、无残留口语词
- 本地 review 通过（含中英一致性与 markdown 结构检查）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 修正设备筛选文档中的示例措辞，将“没插/插了”更新为“未接入/接入了”，提升表述准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->