### PR TITLE
docs: 各级标题移除手工编号，重复小节名并入章节语境

### DIFF
--- a/docs/external/en/api-reference.mdx
+++ b/docs/external/en/api-reference.mdx
@@ -3,10 +3,10 @@ title: API Reference
 description: Complete Wuji Hand SDK (wujihandpy) API reference, including field lists and method descriptions for Hand, Finger, and Joint classes.
 ---
 
-## 1. Field List
+## Field List
 This section introduces all available data fields in wujihandpy.
 
-### 1.1 Hand Layer
+### Hand Layer
 This layer contains device-unique general fields, such as handedness, firmware version, etc.
 #### handedness
 This field indicates the handedness of the dexterous hand (left/right hand, 0 for right, 1 for left).
@@ -33,7 +33,7 @@ This field indicates the measured input voltage of the dexterous hand, in volts.
 - **Type**: `float32`
 - **Read/Write**: Read-only
 
-### 1.2 Joint Layer
+### Joint Layer
 This layer contains fields where each joint holds an independent copy, such as enabled status, target position, etc.
 #### joint_firmware_version
 This field records the version number of the joint driver board firmware.
@@ -184,21 +184,21 @@ This field records the lower position limit of the joint.
 - **Type**: `float64`
 - **Read/Write**: Read-only
 
-## 2. API List
-### 2.1 Hand Class
+## API List
+### Hand Class
 
-#### 2.1.1 Constructor
+#### Constructor
 - `__init__(serial_number=None, *, side=None, usb_pid=0x2000, usb_vid=0x0483, mask=None) -> None`
   *Initialize connection to the dexterous hand. Supports specifying the device by serial number, handedness, USB ID, or device mask.*
 
   - `serial_number`: USB serial number string to select one device exactly
-  - `side`: `"left"` or `"right"`. Selects the device by handedness. Mutually exclusive with `serial_number` (see [Tutorial §1.3](../tutorial#13-filtering-devices))
+  - `side`: `"left"` or `"right"`. Selects the device by handedness. Mutually exclusive with `serial_number` (see [Tutorial - Filtering Devices](../tutorial#filtering-devices))
 
-#### 2.1.2 Finger Access
+#### Finger Access
 - `finger(index) -> Finger`
   *Get the finger object at the specified index, index range 0-4*
 
-#### 2.1.3 Thread Safety Control
+#### Thread Safety Control
 - `disable_thread_safe_check() -> None`
   *Disable thread safety check to allow concurrent multi-threaded access to the Hand object*
 
@@ -206,7 +206,7 @@ This field records the lower position limit of the joint.
 **Note**: After disabling the thread safety check, you must use synchronization mechanisms such as `threading.Lock` to ensure thread-safe operations.
 </Callout>
 
-#### 2.1.4 System Information
+#### System Information
 
 ##### Firmware Information
 - `read_firmware_version(timeout=0.5) -> uint32`
@@ -264,7 +264,7 @@ This field records the lower position limit of the joint.
 - `get_input_voltage() -> float32`
   *Get cached input voltage*
 
-#### 2.1.5 Joint Data (Batch Read, Returns {5,4} Array)
+#### Joint Data (Batch Read, Returns {5,4} Array)
 
 ##### Position Data
 - `read_joint_actual_position(timeout=0.5) -> NDArray[float64]`
@@ -351,7 +351,7 @@ This field records the lower position limit of the joint.
 - `get_joint_firmware_date() -> NDArray[uint32]`
   *Get cached all joint firmware build dates*
 
-#### 2.1.6 Joint Control (Supports Single Value or {5,4} Array)
+#### Joint Control (Supports Single Value or {5,4} Array)
 
 ##### Enable Control
 - `write_joint_enabled(value, timeout=0.5) -> None`
@@ -442,17 +442,17 @@ This field records the lower position limit of the joint.
 - `write_joint_reset_error_unchecked(value_array, timeout=0.5) -> None`
   *Non-blocking batch reset each joint error*
 
-#### 2.1.7 Real-time Controller
+#### Real-time Controller
 - `realtime_controller(enable_upstream, filter) -> IController`
   *Create a real-time controller for high-frequency control scenarios*
 
-### 2.2 Finger Class
+### Finger Class
 
-#### 2.2.1 Joint Access
+#### Joint Access
 - `joint(index) -> Joint`
   *Get the joint object at the specified index, index range 0-3*
 
-#### 2.2.2 Joint Data (Returns 4-Element Array)
+#### Joint Data (Returns 4-Element Array)
 
 ##### Position Data
 - `read_joint_actual_position(timeout=0.5) -> NDArray[float64]`
@@ -539,7 +539,7 @@ This field records the lower position limit of the joint.
 - `get_joint_firmware_date() -> NDArray[uint32]`
   *Get cached all joint firmware build dates of the finger*
 
-#### 2.2.3 Joint Control (Supports Single Value or 4-Element Array)
+#### Joint Control (Supports Single Value or 4-Element Array)
 
 ##### Enable Control
 - `write_joint_enabled(value, timeout=0.5) -> None`
@@ -630,9 +630,9 @@ This field records the lower position limit of the joint.
 - `write_joint_reset_error_unchecked(value_array, timeout=0.5) -> None`
   *Non-blocking batch reset each joint error of the finger*
 
-### 2.3 Joint Class
+### Joint Class
 
-#### 2.3.1 Joint Data (Returns Single Value)
+#### Joint Data (Returns Single Value)
 
 ##### Position Data
 - `read_joint_actual_position(timeout=0.5) -> float64`
@@ -719,7 +719,7 @@ This field records the lower position limit of the joint.
 - `get_joint_firmware_date() -> uint32`
   *Get cached joint firmware build date*
 
-#### 2.3.2 Joint Control (Single Value)
+#### Joint Control (Single Value)
 
 ##### Enable Control
 - `write_joint_enabled(value, timeout=0.5) -> None`
@@ -774,9 +774,9 @@ This field records the lower position limit of the joint.
 - `write_joint_reset_error_unchecked(value, timeout=0.5) -> None`
   *Non-blocking reset joint error*
 
-### 2.4 IController Interface
+### IController Interface
 
-#### 2.4.1 Context Management
+#### Context Management
 - `__enter__() -> IController`
   *Context manager entry supporting with statement*
 - `__exit__(arg0, arg1, arg2) -> None`
@@ -784,7 +784,7 @@ This field records the lower position limit of the joint.
 - `close() -> None`
   *Manually close the real-time controller*
 
-#### 2.4.2 Real-time Data Retrieval
+#### Real-time Data Retrieval
 - `get_joint_actual_position() -> NDArray[float64]`
   *Real-time get all joint actual positions (high-frequency read, returns {5,4} array)*
 - `get_joint_actual_effort() -> NDArray[float64]`
@@ -799,20 +799,20 @@ This field records the lower position limit of the joint.
 - Calculate output percentage via `effort / effort_limit`
 </Callout>
 
-#### 2.4.3 Real-time Data Setting
+#### Real-time Data Setting
 - `set_joint_target_position(value_array) -> None`
   *Real-time set all joint target positions (high-frequency write, parameter is {5,4} array)*
 
 ---
 
-### 2.5 Array Shape Description
+### Array Shape Description
 
 - **Hand Class Batch Operations**: Returns/receives arrays shaped `{5, 4}` (5 fingers × 4 joints)
 - **Finger Class Batch Operations**: Returns/receives arrays shaped `{4}` (4 joints)
 - **Joint Class Operations**: Returns/receives scalar values (single joint)
 - **IController Operations**: Handles arrays shaped `{5, 4}` for high-frequency real-time control
 
-### 2.6 Operation Mode Description
+### Operation Mode Description
 
 - **Synchronous Operations** (`read_*`, `write_*`): Blocking operations, ensure read/write success
 - **Asynchronous Operations** (`*_async`): Returns Awaitable objects, supports await syntax
@@ -822,11 +822,11 @@ This field records the lower position limit of the joint.
 
 ---
 
-## 3. Tactile Sensing Glove
+## Tactile Sensing Glove
 
 The Tactile Sensing Glove is an optional tactile perception accessory for Wuji Hand. The SDK provides device connection and data reading through the `TactileGlove` class.
 
-### 3.1 Core Classes
+### Core Classes
 
 #### TactileHandedness
 
@@ -863,7 +863,7 @@ TactileGlove(serial_number: str | None = None)
 `serial_number` is the USB device serial number. Pass `None` to auto-discover the only attached device. Raises if more than one is present.
 </Callout>
 
-### 3.2 Device Connection
+### Device Connection
 
 #### Auto-discovery
 ```python
@@ -891,7 +891,7 @@ with TactileGlove() as glove:
 - `is_connected() -> bool`: Query connection status
 - `get_handedness() -> TactileHandedness`: Return device handedness
 
-### 3.3 Data Reading
+### Data Reading
 
 #### Blocking read
 
@@ -926,7 +926,7 @@ glove.stop_streaming()
 - `start_streaming` and `read_frame` are mutually exclusive
 - All blocking operations release the Python GIL
 
-### 3.4 Configuration and Diagnostics
+### Configuration and Diagnostics
 
 | Method | Description |
 |--------|-------------|
@@ -944,14 +944,14 @@ glove.stop_streaming()
 | `reset_device()` | Soft reset. The device drops off the bus and re-enumerates—call `connect()` again afterward |
 | `enter_bootloader(magic)` | Jump to bootloader for OTA. Pass `TACTILE_BOOTLOADER_MAGIC` |
 
-### 3.5 Exception Handling
+### Exception Handling
 
 | Exception | Trigger |
 |-----------|---------|
 | `RuntimeError` | `read_frame` timeout, USB device disconnected during read, `read_frame` called when not connected, or `start_streaming` called while already streaming |
 | `TactileError` | Device-reported protocol error from a command (bad length, bad CRC, unknown command, bad payload) |
 
-### 3.6 Complete Example
+### Complete Example
 
 Covers the full `TactileGlove` workflow: auto-discovery and device info queries, host/device clock synchronization, sample-rate configuration, blocking reads and streaming callbacks, data saving, and diagnostic counters. `reset_device` and `enter_bootloader` close the current connection (device reset or jump to bootloader, respectively) and appear only as trailing comments.
 
@@ -1069,7 +1069,7 @@ Collected 326 frames, CRC errors 0, dropouts 0, USB resets 0, uptime 142628802 m
 Saved 326 frames to tactile_data.npy
 ```
 
-### 3.7 Use with Wuji Hand
+### Use with Wuji Hand
 
 `Hand` and `TactileGlove` use independent USB transports and threads, so the two APIs compose in the same process with no extra coordination. The frame callback fires on the glove's streaming consumer thread, while joint commands run on the thread that calls them. This pattern enables closed-loop scenarios where tactile feedback drives motion—for example, scaling joint amplitude by the current pressure peak.
 
@@ -1083,7 +1083,7 @@ Reference example: [`example/joint_with_tactile.py`](https://github.com/wuji-tec
 - Releasing the glove restores the full amplitude
 - Ctrl-C stops streaming, disables joints, and disconnects the glove cleanly
 
-### 3.8 Protocol Reference
+### Protocol Reference
 
 This section is for advanced developers who need to parse tactile data frames directly. The `TactileGlove` class handles all protocol details automatically.
 
@@ -1195,11 +1195,11 @@ with serial.Serial("/dev/ttyACM0", timeout=1.0) as port:
 
 ---
 
-## 4. logging Module
+## logging Module
 
-The `wujihandpy.logging` submodule configures SDK logging at runtime. For default behavior, environment variables, and troubleshooting tips, see [Getting Started - Get Logs](../introduction#53-get-logs).
+The `wujihandpy.logging` submodule configures SDK logging at runtime. For default behavior, environment variables, and troubleshooting tips, see [Getting Started - Get Logs](../introduction#get-logs).
 
-### 4.1 Level Enum
+### Level Enum
 
 | Member | Value | Meaning |
 | :--- | :--- | :--- |
@@ -1211,7 +1211,7 @@ The `wujihandpy.logging` submodule configures SDK logging at runtime. For defaul
 | `Level.Critical` | 5 | Critical errors |
 | `Level.Off` | 6 | Disable logging |
 
-### 4.2 Functions
+### Functions
 
 #### set_log_path
 

--- a/docs/external/en/introduction.mdx
+++ b/docs/external/en/introduction.mdx
@@ -3,15 +3,15 @@ title: Getting Started
 description: Learn about Wuji Hand SDK (wujihandpy) installation, quick start examples, and core concepts including device model and data model.
 ---
 
-## 1. Compatibility and Requirements
+## Compatibility and Requirements
 - CPU: x86_64 (AMD64) / arm64 (aarch64)
 - Python: 3.8–3.14
 - OS: Ubuntu 22.04 LTS / Ubuntu 24.04 LTS
 
-## 2. Installation Guide
+## Installation Guide
 This section covers the installation of wujihandpy, system requirements, and common troubleshooting.  
 
-### 2.1 Installation
+### Installation
 wujihandpy supports one-step installation via `pip`:
 ```bash
 python3 -m pip install wujihandpy
@@ -29,10 +29,10 @@ sudo udevadm trigger
 ```
 
 <Callout type="info">
-  Note: For common installation errors and fixes, see [Troubleshooting - Installation](#51-installation) at the end of this page.
+  Note: For common installation errors and fixes, see [Troubleshooting - Installation Issues](#installation-issues) at the end of this page.
 </Callout>
 
-## 3. Quick Start
+## Quick Start
 This section provides a minimal working example to quickly test the dexterous hand with the wujihandpy library.
 ```python
 # quickstart.py
@@ -59,13 +59,13 @@ python3 quickstart.py
 ```
 
 <Callout type="info">
-  Note: For common connection and permission issues during quick start, see [Troubleshooting - Quick Start](#52-quick-start) at the end of this page.
+  Note: For common connection and permission issues during quick start, see [Troubleshooting - Quick Start Issues](#quick-start-issues) at the end of this page.
 </Callout>
 
-## 4. Core Concepts
+## Core Concepts
 This section introduces wujihandpy's device model and data model to help you understand the library's overall architecture and usage patterns.
 
-### 4.1 Device Model
+### Device Model
 wujihandpy has a three-layer device model: Hand, Finger, and Joint. The hierarchy is: `Hand.finger(i) -> Finger`, `Finger.joint(j) -> Joint`. Specifically:
 - **Hand** represents the complete dexterous hand device and can be created via wujihandpy.Hand().
 - **Finger** is a lightweight reference to Hand, does not hold independent state, and can be constructed and destroyed multiple times. Finger objects can be constructed via `hand.finger(i)` (0 ≤ i < 5), where i corresponds to actual fingers as follows:
@@ -79,10 +79,10 @@ wujihandpy has a three-layer device model: Hand, Finger, and Joint. The hierarch
   - ...
   - 3: Distal joint
 
-### 4.2 Data Model
+### Data Model
 Data consists of readable/writable objects. Similar to devices, data also has a hierarchical relationship:
 <Callout type="info">
-  Note: Only some data fields are listed here as examples. For the complete API Reference, see [Field List](../api-reference/#1-field-list).
+  Note: Only some data fields are listed here as examples. For the complete API Reference, see [Field List](../api-reference/#field-list).
 </Callout>
 - **Hand** layer: Data unique to the entire hand resides at this layer, for example:
   - `handedness`: Handedness (left/right hand)
@@ -102,11 +102,11 @@ Data consists of readable/writable objects. Similar to devices, data also has a 
   Note: All data belonging to the Joint layer is prefixed with `joint`.
 </Callout>
 
-## 5. Troubleshooting
+## Troubleshooting
 
-### 5.1 Installation
+### Installation Issues
 
-#### 5.1.1 Upgrade pip
+#### Upgrade pip
 If you encounter `Could not find a version that satisfies the requirement`, for example in an older Python or pip environment:
 ```text
 ERROR: Could not find a version that satisfies the requirement wujihandpy (from versions: none)
@@ -116,9 +116,9 @@ Consider upgrading pip and using the upgraded pip to install:
 ```bash
 python3 -m pip install --upgrade pip && python3 -m pip install wujihandpy
 ```
-If the issue remains unresolved, please verify that your system version and Python version meet the [Compatibility and Requirements](#1-compatibility-and-requirements).
+If the issue remains unresolved, please verify that your system version and Python version meet the [Compatibility and Requirements](#compatibility-and-requirements).
 
-#### 5.1.2 Using Virtual Environments
+#### Using Virtual Environments
 If you encounter `This environment is externally managed`, for example in Ubuntu environments where the system Python is managed by the OS:
 ```text
 error: externally-managed-environment
@@ -144,9 +144,9 @@ hint: See PEP 668 for the detailed specification.
 ```
 This indicates that pip is managed by the system package manager and requires using a virtual environment (venv) for installation.
 
-### 5.2 Quick Start
+### Quick Start Issues
 
-#### 5.2.1 Dexterous Hand Not Connected
+#### Dexterous Hand Not Connected
 ```text
 [ERROR] No device found with specified vendor id (0x0483)
 Traceback (most recent call last):
@@ -162,7 +162,7 @@ Bus 001 Device 032: ID 0483:2000 WUJITECH WUJIHAND
 ```
 When using a USB-C to USB-C cable to connect the dexterous hand, some computers may not properly recognize the device. Please try replacing it with a USB-A to USB-C cable.
 
-#### 5.2.2 Insufficient Permissions
+#### Insufficient Permissions
 ```text
 [ERROR] No device found with specified vendor id (0x0483)
 [ERROR]   Device 1 (0483:2000): Ignored because device could not be opened: -3 (ERROR_ACCESS)
@@ -174,16 +174,16 @@ Traceback (most recent call last):
 RuntimeError: Failed to init.
 ```
 If you encounter the above error (ERROR_ACCESS), it indicates that the current user does not have read/write permissions for the USB device.
-Please check the Linux udev configuration section in [Installation](#21-installation), complete the permission configuration, and try again.
+Please check the Linux udev configuration section in [Installation](#installation), complete the permission configuration, and try again.
 <Callout type="warning">
   Note: If developing in a Docker container (DevContainer), the udev configuration commands must still be executed on the host machine.
 </Callout>
 
-### 5.3 Get Logs
+### Get Logs
 
 SDK runtime logs are stored in `~/.wuji/log/` by default. File names follow `{timestamp}_{pid}.log`, with each file rolling at 10 MB and up to 5 historical files retained. Send the latest log to technical support when reporting an issue.
 
-#### 5.3.1 Custom Path and Level
+#### Custom Path and Level
 
 **Configure through environment variables (recommended, zero code)**
 
@@ -219,9 +219,9 @@ wuji_logging.set_log_level(wuji_logging.Level.Debug)
 hand = wujihandpy.Hand()
 ```
 
-For the full API reference and call-timing constraints, see [API Reference - logging Module](../api-reference#4-logging-module).
+For the full API reference and call-timing constraints, see [API Reference - logging Module](../api-reference#logging-module).
 
-#### 5.3.2 Collect Detailed Logs
+#### Collect Detailed Logs
 
 The default `info` level captures only key events. When you need detailed command flow analysis (for example, a command was sent but the actual state didn't follow), switch to `debug` for SDO/PDO traffic, or `trace` for the raw TX/RX bytes as well:
 

--- a/docs/external/en/tutorial.mdx
+++ b/docs/external/en/tutorial.mdx
@@ -3,10 +3,10 @@ title: Tutorial
 description: Wuji Hand SDK (wujihandpy) tutorial covering device connection, synchronous/asynchronous read/write, and real-time control.
 ---
 
-## 1. Device Connection and Selection
+## Device Connection and Selection
 This section describes how to connect to dexterous hand devices in wujihandpy and how to filter devices when multiple devices are present.
 
-### 1.1 Interface Overview
+### Connection and Filtering Interface Overview
 ```python
 class Hand:
     def __init__(
@@ -19,14 +19,14 @@ class Hand:
         ...
 ```
 
-### 1.2 Connecting to a Device
+### Connecting to a Device
 Call `wujihandpy.Hand()` to create a `Hand` object and connect to the dexterous hand:
 ```python
 hand = wujihandpy.Hand()
 ```
 If only one dexterous hand is connected to the system, it will automatically connect to that device.
 
-### 1.3 Filtering Devices
+### Filtering Devices
 When multiple dexterous hands are connected to the system, using the no-argument constructor will result in an error. For example:
 ```
 [ERROR] 2 devices found with specified vendor id (0x0483)
@@ -66,7 +66,7 @@ Common failure cases:
 - Two hands of the same side are connected → raises `ConnectionError` suggesting `serial_number` instead
 </Callout>
 
-### 1.4 Querying Serial Numbers
+### Querying Serial Numbers
 
 The dexterous hand has two types of serial numbers:
 
@@ -96,9 +96,9 @@ print(product_sn)  # e.g. "WJ-DH5-R-2501001"
 ```
 
 
-## 2. Reading Data
+## Reading Data
 This section describes how to read data in synchronous mode.
-### 2.1 Interface Overview
+### Reading Interface Overview
 Calling `read_*` series functions sends a synchronous read request to the dexterous hand and blocks the current thread until the device returns a result. Function return indicates that the read has completed successfully.
 
 <Callout type="warning">
@@ -108,11 +108,11 @@ Calling `read_*` series functions sends a synchronous read request to the dexter
 
   For real-time control scenarios, consider:
 
-  - Using [Unidirectional/Bidirectional Real-Time Controllers](#4-real-time-control)
-  - Using [Async APIs](#5-async-readwrite) in a low-speed bypass loop
+  - Using [Unidirectional/Bidirectional Real-Time Controllers](#real-time-control)
+  - Using [Async APIs](#async-readwrite) in a low-speed bypass loop
 </Callout>
 
-### 2.2 Single Value Reading
+### Single Value Reading
 When the read level matches the object level, the function returns a single scalar value.
 ```python
 class Hand:
@@ -135,7 +135,7 @@ Read the current position of the index finger's proximal joint (Joint level) usi
 position = hand.finger(1).joint(0).read_joint_actual_position()
 ```
 
-### 2.3 Batch Reading
+### Batch Reading
 When the read level is lower than the object level, the function returns a matrix containing multiple data points.
 ```python
 class Hand:
@@ -168,13 +168,13 @@ Similarly, you can request all joint positions for a single finger using `finger
 [ 0.382  0.241 -0.003 -0.275]
 ```
 
-### 2.4 More Examples
+### More Reading Examples
 - [example/joint/1.read.py](https://github.com/wuji-technology/wujihandpy/blob/main/example/joint/1.read.py)
 
 
-## 3. Writing Data
+## Writing Data
 This section describes how to write data in synchronous mode.
-### 3.1 Interface Overview
+### Writing Interface Overview
 Calling `write_*` series functions sends a synchronous write request to the dexterous hand and blocks the current thread until the device returns a result. Function return indicates that the write has completed successfully.
 
 <Callout type="warning">
@@ -184,11 +184,11 @@ Calling `write_*` series functions sends a synchronous write request to the dext
 
   For real-time control scenarios, consider:
 
-  - Using [Unidirectional/Bidirectional Real-Time Controllers](#4-real-time-control)
-  - Using [Async APIs](#5-async-readwrite) in a low-speed bypass loop
+  - Using [Unidirectional/Bidirectional Real-Time Controllers](#real-time-control)
+  - Using [Async APIs](#async-readwrite) in a low-speed bypass loop
 </Callout>
 
-### 3.2 Single Value Writing
+### Single Value Writing
 When the write level matches the object level, the function uses a single scalar value.
 ```python
 class Hand:
@@ -207,7 +207,7 @@ Enable the index finger's proximal joint (Joint level):
 hand.finger(1).joint(0).write_joint_enabled(True)
 ```
 
-### 3.3 Batch Writing
+### Batch Writing
 When the write level is lower than the object level, the function can accept either a single scalar value or a matrix containing multiple data points.
 ```python
 class Hand:
@@ -269,7 +269,7 @@ hand.write_joint_target_position(
 )
 ```
 
-### 3.4 Invalid Value Writing
+### Invalid Value Writing
 
 Typically, invalid value writes are handled automatically, such as:
 - Angles exceeding the valid range are automatically clamped to upper and lower bounds.
@@ -279,14 +279,14 @@ However, this is not absolute. When values have logical errors, such as:
 
 This will cause the operation to fail and throw a TimeoutError.
 
-### 3.5 More Examples
+### More Writing Examples
 - [example/joint/2.write.py](https://github.com/wuji-technology/wujihandpy/blob/main/example/joint/2.write.py)
 
 
-## 4. Real-Time Control
+## Real-Time Control
 This section describes how to control the dexterous hand in real-time mode in wujihandpy.
 
-### 4.1 Interface Overview
+### Real-Time Control Interface Overview
 ```python
 class Hand:
     def realtime_controller(self, enable_upstream: bool, filter: filter.IFilter) -> IController:
@@ -306,7 +306,7 @@ class IController:
 Calling `Hand.realtime_controller()` puts the dexterous hand into real-time control mode and returns a real-time controller object `IController`.
 After entering real-time control mode, a 16 kHz real-time filter starts on the motor side to smooth control signals into a stable 16 kHz stream.
 
-### 4.2 Filters
+### Filters
 The real-time controller requires a filter object (`filter.IFilter`) to smoothly adjust target values.
 <Callout type="info">
   The initial value of the filter is automatically set to the actual position of the dexterous hand, so there is no need to worry about initial transition issues.
@@ -319,7 +319,7 @@ wujihandpy provides the following commonly used filters:
   Because filter logic runs on the motor driver board, custom filters are not supported.
 </Callout>
 
-### 4.3 Context Manager
+### Context Manager
 `IController` can be used as a context manager:
 
 ```python
@@ -334,13 +334,13 @@ When the `with` block ends, `controller.close()` is automatically called, ensuri
 #### Automatic Destruction
 If a context manager is not used, `IController` will automatically call `close()` during destruction. Due to Python's garbage collection delay, the dexterous hand may not immediately exit real-time mode. If precise control of exit timing is not needed, you can directly rely on destruction behavior.
 
-### 4.4 Real-Time Writing
+### Real-Time Writing
 ```python
 def set_joint_target_position(self, value_array: np.NDArray[np.float64]) -> None: ...
 ```
 The `set_joint_target_position()` function sends target control values to the motor driver board as quickly as possible without blocking.
 
-### 4.5 Real-Time Reading
+### Real-Time Reading
 The motor automatically reports current position and effort at a 1 kHz rate. The following functions are non-blocking and immediately return the latest cached readings.
 
 ```python
@@ -382,14 +382,14 @@ finally:
     hand.write_joint_enabled(False)
 ```
 
-### 4.6 Advanced Examples
+### Advanced Real-Time Control Examples
 - [example/joint/3.realtime.py](https://github.com/wuji-technology/wujihandpy/blob/main/example/joint/3.realtime.py)
 
 
-## 5. Async Read/Write
+## Async Read/Write
 This section describes how to read/write data in asynchronous mode in wujihandpy.
 
-### 5.1 Interface Overview
+### Async Interface Overview
 Both read and write interfaces provide asynchronous versions with function names suffixed with `_async` for performing non-blocking I/O operations in coroutine environments.
 ```python
 async def read_<dataname>_async(self) -> datatype: ...
@@ -410,8 +410,8 @@ When calling asynchronous interfaces, use `await`. The event loop is not blocked
 
   For real-time control scenarios, consider:
 
-  - Using [Unidirectional/Bidirectional Real-Time Controllers](#4-real-time-control)
-  - Using [Async APIs](#5-async-readwrite) in a low-speed bypass loop
+  - Using [Unidirectional/Bidirectional Real-Time Controllers](#real-time-control)
+  - Using [Async APIs](#async-readwrite) in a low-speed bypass loop
 </Callout>
 
 **Example**
@@ -439,14 +439,14 @@ async def main():
 asyncio.run(main())
 ```
 
-### 5.2 Advanced Examples
+### Advanced Async Examples
 - [example/joint/4.async.py](https://github.com/wuji-technology/wujihandpy/blob/main/example/joint/4.async.py)
 
 
-## 6. Multi-threaded Operations
+## Multi-Threaded Operations
 This section describes how to perform multi-threaded operations in wujihandpy.
 
-### 6.1 Interface Overview
+### Multi-Threading Interface Overview
 By default, wujihandpy performs thread safety checks on the `Hand` object to prevent data race conditions from concurrent multi-threaded access. If you need to use the same `Hand` object in a multi-threaded environment, you must first call `Hand.disable_thread_safe_check()` to disable this check.
 
 ```python
@@ -455,7 +455,7 @@ class Hand:
         ...
 ```
 
-### 6.2 Multi-threading Safety Considerations
+### Multi-Threading Safety Considerations
 
 <Callout type="warning">
 **Important**: After disabling the thread safety check, you are responsible for ensuring thread safety.
@@ -527,7 +527,7 @@ with hand.realtime_controller(
         t.join()
 ```
 
-### 6.3 Expected Output
+### Expected Output
 
 After running the example, the terminal will display output similar to the following:
 
@@ -563,14 +563,14 @@ Thread safety check disabled, multi-threaded access enabled
 - The two threads output alternately, and the order may be interleaved (this is normal behavior for multi-threading)
 - F1 (thumb) remains stationary, while F2 (index), F3 (middle), F4 (ring), and F5 (pinky) perform periodic flexion-extension movements
 
-### 6.4 Advanced Examples
+### Advanced Multi-Threading Examples
 - [example/joint/5.multithread.py](https://github.com/wuji-technology/wujihandpy/blob/main/example/joint/5.multithread.py)
 
 
-## 7. USB Disconnect Handling
+## USB Disconnect Handling
 During operation, the USB connection between the dexterous hand and the computer can drop—for example, when the data cable is unplugged. This section describes how wujihandpy behaves on disconnect and how to catch disconnect exceptions.
 
-### 7.1 Disconnect Behavior
+### Disconnect Behavior
 On disconnect, wujihandpy raises an exception. Catch it to recover without crashing the process.
 
 An operation started after a disconnect raises Python's built-in `ConnectionError` immediately, without waiting for the 500 ms timeout. Affected interfaces include:
@@ -582,7 +582,7 @@ An operation started after a disconnect raises Python's built-in `ConnectionErro
   An async request already in flight at the moment of disconnect is an exception: it ends with `TimeoutError` rather than `ConnectionError`. If your code runs concurrent async operations, catch their common base class `OSError` to cover both disconnect and timeout.
 </Callout>
 
-### 7.2 Catching Disconnect Exceptions
+### Catching Disconnect Exceptions
 Wrap device operations in a `try` block and catch `ConnectionError` to handle disconnects:
 
 ```python
@@ -609,7 +609,7 @@ if __name__ == "__main__":
 
 Run the script, then unplug the USB cable while it reads. The loop is interrupted immediately by `ConnectionError`, and the program exits normally without crashing.
 
-### 7.3 Disconnect Detection in Real-Time Control Mode
+### Disconnect Detection in Real-Time Control Mode
 <Callout type="warning">
   The real-time controller's non-blocking interfaces (`set_joint_target_position()`, `get_joint_actual_position()`, `get_joint_actual_effort()`) do **not** raise `ConnectionError` on disconnect.
 </Callout>
@@ -618,5 +618,5 @@ Real-time control loops rely on high-speed PDO data. On disconnect, these interf
 
 When the real-time controller is used as a context manager, the end of the `with` block automatically calls `close()` to clean up. `close()` also returns safely on disconnect, so no extra handling is needed.
 
-### 7.4 More Examples
+### More Disconnect Handling Examples
 - [example/joint/6.disconnect.py](https://github.com/wuji-technology/wujihandpy/blob/main/example/joint/6.disconnect.py)

--- a/docs/external/zh/api-reference.mdx
+++ b/docs/external/zh/api-reference.mdx
@@ -3,10 +3,10 @@ title: API 参考
 description: Wuji Hand SDK (wujihandpy) 完整 API 参考，包括 Hand、Finger、Joint 类的字段列表和方法说明。
 ---
 
-## 1. 字段列表
+## 字段列表
 本节介绍 wujihandpy 中所有可用的数据字段。
 
-### 1.1 Hand 层
+### Hand 层
 该层包含整手设备唯一的通用字段，例如手性、固件版本等。  
 #### handedness
 该字段表示灵巧手的手性（左/右手，0 表示右手，1 表示左手）。  
@@ -33,7 +33,7 @@ description: Wuji Hand SDK (wujihandpy) 完整 API 参考，包括 Hand、Finger
 - **类型**：`float32`
 - **读写属性**：只读
 
-### 1.2 Joint 层
+### Joint 层
 该层包含每关节持有一个独立副本的字段，例如使能、目标位置等。  
 #### joint_firmware_version
 该字段记录关节驱动板固件的版本号。  
@@ -184,21 +184,21 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 - **类型**：`float64`
 - **读写属性**：只读
 
-## 2. API 列表
-### 2.1 Hand 类
+## API 列表
+### Hand 类
 
-#### 2.1.1 构造函数
+#### 构造函数
 - `__init__(serial_number=None, *, side=None, usb_pid=0x2000, usb_vid=0x0483, mask=None) -> None`
   *初始化灵巧手连接，支持通过序列号、左右手、USB ID 或设备掩码指定设备*
 
   - `serial_number`：USB 序列号字符串，精确指定一台设备
-  - `side`：`"left"` 或 `"right"`，按手性选择设备，与 `serial_number` 互斥（详见 [教程 §1.3](../tutorial#13-筛选设备)）
+  - `side`：`"left"` 或 `"right"`，按手性选择设备，与 `serial_number` 互斥（详见 [教程 - 筛选设备](../tutorial#筛选设备)）
 
-#### 2.1.2 手指访问
+#### 手指访问
 - `finger(index) -> Finger`
   *获取指定索引的手指对象，索引范围 0-4*
 
-#### 2.1.3 线程安全控制
+#### 线程安全控制
 - `disable_thread_safe_check() -> None`
   *禁用线程安全检查，允许在多线程环境中并发访问 Hand 对象*
 
@@ -206,7 +206,7 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 **注意**：禁用线程安全检查后，用户需要自行使用互斥锁（`threading.Lock`）确保多线程操作的正确性。
 </Callout>
 
-#### 2.1.4 系统信息
+#### 系统信息
 
 ##### 固件信息
 - `read_firmware_version(timeout=0.5) -> uint32`
@@ -264,7 +264,7 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 - `get_input_voltage() -> float32`
   *获取缓存的输入电压*
 
-#### 2.1.5 关节数据（批量读取，返回 {5,4} 数组）
+#### 关节数据（批量读取，返回 {5,4} 数组）
 
 ##### 位置数据
 - `read_joint_actual_position(timeout=0.5) -> NDArray[float64]`
@@ -351,7 +351,7 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 - `get_joint_firmware_date() -> NDArray[uint32]`
   *获取缓存的所有关节固件编译日期*
 
-#### 2.1.6 关节控制（支持单个值或 {5,4} 数组）
+#### 关节控制（支持单个值或 {5,4} 数组）
 
 ##### 使能控制
 - `write_joint_enabled(value, timeout=0.5) -> None`
@@ -442,17 +442,17 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 - `write_joint_reset_error_unchecked(value_array, timeout=0.5) -> None`
   *非阻塞批量重置各关节错误*
 
-#### 2.1.7 实时控制器
+#### 实时控制器
 - `realtime_controller(enable_upstream, filter) -> IController`
   *创建实时控制器，用于高频控制场景*
 
-### 2.2 Finger 类
+### Finger 类
 
-#### 2.2.1 关节访问
+#### 关节访问
 - `joint(index) -> Joint`
   *获取指定索引的关节对象，索引范围 0-3*
 
-#### 2.2.2 关节数据（返回 4 元素数组）
+#### 关节数据（返回 4 元素数组）
 
 ##### 位置数据
 - `read_joint_actual_position(timeout=0.5) -> NDArray[float64]`
@@ -539,7 +539,7 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 - `get_joint_firmware_date() -> NDArray[uint32]`
   *获取缓存的手指所有关节固件编译日期*
 
-#### 2.2.3 关节控制（支持单个值或 4 元素数组）
+#### 关节控制（支持单个值或 4 元素数组）
 
 ##### 使能控制
 - `write_joint_enabled(value, timeout=0.5) -> None`
@@ -630,9 +630,9 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 - `write_joint_reset_error_unchecked(value_array, timeout=0.5) -> None`
   *非阻塞批量重置手指各关节错误*
 
-### 2.3 Joint 类
+### Joint 类
 
-#### 2.3.1 关节数据（返回单个值）
+#### 关节数据（返回单个值）
 
 ##### 位置数据
 - `read_joint_actual_position(timeout=0.5) -> float64`
@@ -719,7 +719,7 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 - `get_joint_firmware_date() -> uint32`
   *获取缓存的关节固件编译日期*
 
-#### 2.3.2 关节控制（单个值）
+#### 关节控制（单个值）
 
 ##### 使能控制
 - `write_joint_enabled(value, timeout=0.5) -> None`
@@ -774,9 +774,9 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 - `write_joint_reset_error_unchecked(value, timeout=0.5) -> None`
   *非阻塞重置关节错误*
 
-### 2.4 IController 接口
+### IController 接口
 
-#### 2.4.1 上下文管理
+#### 上下文管理
 - `__enter__() -> IController`
   *支持 with 语句的上下文管理器入口*
 - `__exit__(arg0, arg1, arg2) -> None`
@@ -784,7 +784,7 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 - `close() -> None`
   *手动关闭实时控制器*
 
-#### 2.4.2 实时数据获取
+#### 实时数据获取
 - `get_joint_actual_position() -> NDArray[float64]`
   *实时获取所有关节实际位置（高频读取，返回 {5,4} 数组）*
 - `get_joint_actual_effort() -> NDArray[float64]`
@@ -799,20 +799,20 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 - 可通过 `effort / effort_limit` 计算输出百分比
 </Callout>
 
-#### 2.4.3 实时数据设置
+#### 实时数据设置
 - `set_joint_target_position(value_array) -> None`
   *实时设置所有关节目标位置（高频写入，参数为 {5,4} 数组）*
 
 ---
 
-### 2.5 数组形状说明
+### 数组形状说明
 
 - **Hand 类批量操作**：返回/接收形状为 `{5, 4}` 的数组（5个手指 × 4个关节）
 - **Finger 类批量操作**：返回/接收形状为 `{4}` 的数组（4个关节）
 - **Joint 类操作**：返回/接收标量值（单个关节）
 - **IController 操作**：处理形状为 `{5, 4}` 的数组，用于高频实时控制
 
-### 2.6 操作模式说明
+### 操作模式说明
 
 - **同步操作** (`read_*`, `write_*`)：阻塞操作，确保读/写成功
 - **异步操作** (`*_async`)：返回 Awaitable 对象，支持 await 语法
@@ -822,11 +822,11 @@ URDF 文件中的关节范围是理论设计值，经过保守缩放以考虑加
 
 ---
 
-## 3. 触觉感知手套
+## 触觉感知手套
 
 触觉感知手套（Tactile Sensing Glove）是 Wuji Hand 的选配触觉感知配件。SDK 通过 `TactileGlove` 类提供设备连接和数据读取接口。
 
-### 3.1 核心类
+### 核心类
 
 #### TactileHandedness
 
@@ -863,7 +863,7 @@ TactileGlove(serial_number: str | None = None)
 `serial_number` 为 USB 设备序列号。传 `None` 时自动发现总线上唯一的设备，若存在多台会抛出异常。
 </Callout>
 
-### 3.2 设备连接
+### 设备连接
 
 #### 自动发现
 ```python
@@ -891,7 +891,7 @@ with TactileGlove() as glove:
 - `is_connected() -> bool`：查询连接状态
 - `get_handedness() -> TactileHandedness`：返回设备手型
 
-### 3.3 数据读取
+### 数据读取
 
 #### 阻塞读取
 
@@ -926,7 +926,7 @@ glove.stop_streaming()
 - `start_streaming` 与 `read_frame` 互斥，不可同时使用
 - 所有阻塞操作释放 Python GIL
 
-### 3.4 配置与诊断
+### 配置与诊断
 
 | 方法 | 说明 |
 |------|------|
@@ -944,14 +944,14 @@ glove.stop_streaming()
 | `reset_device()` | 软复位。设备会从总线断开并重新枚举，调用后需重新 `connect()` |
 | `enter_bootloader(magic)` | 跳转至 bootloader 以执行 OTA，传入 `TACTILE_BOOTLOADER_MAGIC` |
 
-### 3.5 异常处理
+### 异常处理
 
 | 异常 | 触发场景 |
 |------|----------|
 | `RuntimeError` | `read_frame` 超时、读取期间 USB 断开、未连接时调用 `read_frame`，或在已流式时重复调用 `start_streaming` |
 | `TactileError` | 命令返回设备协议错误（长度错误、CRC 错误、未知命令、负载错误） |
 
-### 3.6 完整示例
+### 完整示例
 
 覆盖 `TactileGlove` 的完整工作流：自动发现与设备信息查询、主机/设备时钟同步、采样率配置、阻塞读取与流式回调、数据保存以及诊断计数器读取。`reset_device` / `enter_bootloader` 会断开当前连接（设备复位或进入 bootloader），仅在末尾以注释形式给出。
 
@@ -1069,7 +1069,7 @@ Collected 326 frames, CRC errors 0, dropouts 0, USB resets 0, uptime 142628802 m
 Saved 326 frames to tactile_data.npy
 ```
 
-### 3.7 与 Wuji Hand 联合使用
+### 与 Wuji Hand 联合使用
 
 `Hand` 与 `TactileGlove` 使用独立的 USB 传输和线程，可在同一进程内并行使用，无需额外协调。帧回调在触觉手套的流式消费线程中触发，关节命令运行在调用它们的线程上。该模式适合用触觉反馈驱动运动控制的闭环场景，例如根据当前压力峰值动态缩放关节运动幅度。
 
@@ -1083,7 +1083,7 @@ Saved 326 frames to tactile_data.npy
 - 松手后幅度自动恢复
 - Ctrl-C 退出时自动停止流式、关闭关节使能并断开手套
 
-### 3.8 协议参考
+### 协议参考
 
 本节面向需要自行解析触觉数据帧的高级开发者。使用 SDK 的 `TactileGlove` 类时无需关注协议细节。
 
@@ -1195,11 +1195,11 @@ with serial.Serial("/dev/ttyACM0", timeout=1.0) as port:
 
 ---
 
-## 4. logging 模块
+## logging 模块
 
-`wujihandpy.logging` 子模块用于在运行时配置 SDK 日志行为。默认行为、环境变量与排查建议见 [入门 - 获取日志](../introduction#53-获取日志)。
+`wujihandpy.logging` 子模块用于在运行时配置 SDK 日志行为。默认行为、环境变量与排查建议见 [入门 - 获取日志](../introduction#获取日志)。
 
-### 4.1 Level 枚举
+### Level 枚举
 
 | 成员 | 数值 | 含义 |
 | :--- | :--- | :--- |
@@ -1211,7 +1211,7 @@ with serial.Serial("/dev/ttyACM0", timeout=1.0) as port:
 | `Level.Critical` | 5 | 严重错误 |
 | `Level.Off` | 6 | 关闭日志 |
 
-### 4.2 函数
+### 函数
 
 #### set_log_path
 

--- a/docs/external/zh/introduction.mdx
+++ b/docs/external/zh/introduction.mdx
@@ -3,15 +3,15 @@ title: 入门
 description: 了解 Wuji Hand SDK (wujihandpy) 的安装配置、快速上手示例及核心概念，包括设备模型和数据模型。
 ---
 
-## 1. 兼容性与要求
+## 兼容性与要求
 - CPU：x86_64 (AMD64) / arm64 (aarch64)
 - Python：3.8–3.14
 - 操作系统：Ubuntu 22.04 LTS / Ubuntu 24.04 LTS
 
-## 2. 安装指南
+## 安装指南
 本节介绍 wujihandpy 的安装方法和常见问题解决。  
 
-### 2.1 安装
+### 安装
 wujihandpy 支持 `pip` 一键安装：
 ```bash
 python3 -m pip install wujihandpy
@@ -29,10 +29,10 @@ sudo udevadm trigger
 ```
 
 <Callout type="info">
-  说明：安装过程中常见报错及处理方式，参见文末的 [故障排除 - 安装](#51-安装)。
+  说明：安装过程中常见报错及处理方式，参见文末的 [故障排除 - 安装问题](#安装问题)。
 </Callout>
 
-## 3. 快速上手
+## 快速上手
 本节给出最小可运行示例，快速测试灵巧手与 wujihandpy 库。
 ```python
 # quickstart.py
@@ -59,13 +59,13 @@ python3 quickstart.py
 ```
 
 <Callout type="info">
-  说明：快速上手阶段常见的连接与权限问题，参见文末的 [故障排除 - 快速上手](#52-快速上手)。
+  说明：快速上手阶段常见的连接与权限问题，参见文末的 [故障排除 - 快速上手问题](#快速上手问题)。
 </Callout>
 
-## 4. 核心概念
+## 核心概念
 本节介绍 wujihandpy 的设备模型和数据模型，帮助理解库的整体架构和使用方式。
 
-### 4.1 设备模型
+### 设备模型
 wujihandpy 拥有三层设备模型，分别为 Hand, Finger, Joint。其层级关系为：`Hand.finger(i) -> Finger`，`Finger.joint(j) -> Joint`。其中，
 - **Hand** 表示完整的灵巧手设备，可通过 wujihandpy.Hand() 创建。
 - **Finger** 是对 Hand 的轻量引用，不持有独立状态，可多次构造和销毁。Finger 对象可由 `hand.finger(i)` (0 ≤ i < 5) 构造，i 与实际手指的具体对应关系如下：
@@ -79,10 +79,10 @@ wujihandpy 拥有三层设备模型，分别为 Hand, Finger, Joint。其层级�
   - ...
   - 3：远端关节
 
-### 4.2 数据模型
+### 数据模型
 数据是可读/可写的对象，与设备类似，数据也存在层级关系：
 <Callout type="info">
-  说明：此处仅列举部分数据字段作为示例，完整 API Reference 参见 [字段列表](../api-reference/#1-字段列表)。
+  说明：此处仅列举部分数据字段作为示例，完整 API Reference 参见 [字段列表](../api-reference/#字段列表)。
 
 </Callout>
 - **Hand** 层：整手唯一的数据位于该层，例如：
@@ -103,11 +103,11 @@ wujihandpy 拥有三层设备模型，分别为 Hand, Finger, Joint。其层级�
   说明：属于 Joint 层的所有数据，在命名上均以 `joint` 开头。
 </Callout>
 
-## 5. 故障排除
+## 故障排除
 
-### 5.1 安装
+### 安装问题
 
-#### 5.1.1 升级 pip
+#### 升级 pip
 若出现 `Could not find a version that satisfies the requirement`，例如在较旧的 Python 或 pip 环境中：
 ```text
 ERROR: Could not find a version that satisfies the requirement wujihandpy (from versions: none)
@@ -117,9 +117,9 @@ ERROR: No matching distribution found for wujihandpy
 ```bash
 python3 -m pip install --upgrade pip && python3 -m pip install wujihandpy
 ```
-若问题未解决，请确认系统版本和 Python 版本是否符合 [兼容性与要求](#1-兼容性与要求)。
+若问题未解决，请确认系统版本和 Python 版本是否符合 [兼容性与要求](#兼容性与要求)。
 
-#### 5.1.2 使用虚拟环境
+#### 使用虚拟环境
 若出现 `This environment is externally managed`，例如在启用了系统托管 Python 的 Ubuntu 环境中：
 ```text
 error: externally-managed-environment
@@ -145,9 +145,9 @@ hint: See PEP 668 for the detailed specification.
 ```
 这表示 pip 被系统包管理器接管，需要使用虚拟环境 (venv) 进行安装。
 
-### 5.2 快速上手
+### 快速上手问题
 
-#### 5.2.1 灵巧手未连接
+#### 灵巧手未连接
 ```text
 [ERROR] No device found with specified vendor id (0x0483)
 Traceback (most recent call last):
@@ -163,7 +163,7 @@ Bus 001 Device 032: ID 0483:2000 WUJITECH WUJIHAND
 ```
 当使用 USB-C to USB-C 线束连接灵巧手时，部分电脑可能无法正确识别设备，请更换为 USB-A to USB-C 线束重试。
 
-#### 5.2.2 权限不足
+#### 权限不足
 ```text
 [ERROR] No device found with specified vendor id (0x0483)
 [ERROR]   Device 1 (0483:2000): Ignored because device could not be opened: -3 (ERROR_ACCESS)
@@ -175,16 +175,16 @@ Traceback (most recent call last):
 RuntimeError: Failed to init.
 ```
 若出现以上报错（ERROR_ACCESS），表示当前用户对 USB 设备没有读写权限。
-请检查 [安装](#21-安装) 中的 Linux udev 配置部分，完成权限配置后重试。
+请检查 [安装](#安装) 中的 Linux udev 配置部分，完成权限配置后重试。
 <Callout type="warning">
   注意：若在 Docker 镜像中开发 (DevContainer)，udev 配置命令仍需在宿主机中执行。
 </Callout>
 
-### 5.3 获取日志
+### 获取日志
 
 SDK 运行日志默认位于 `~/.wuji/log/`，文件名 `{timestamp}_{pid}.log`，单文件 10 MB 滚动，最多保留 5 个历史文件。遇到问题时将最近的日志发送给售后支持即可协助定位。
 
-#### 5.3.1 自定义路径与级别
+#### 自定义路径与级别
 
 **通过环境变量配置（推荐，零代码）**
 
@@ -220,9 +220,9 @@ wuji_logging.set_log_level(wuji_logging.Level.Debug)
 hand = wujihandpy.Hand()
 ```
 
-完整 API 参考与调用时机约束见 [API 参考 - logging 模块](../api-reference#4-logging-模块)。
+完整 API 参考与调用时机约束见 [API 参考 - logging 模块](../api-reference#logging-模块)。
 
-#### 5.3.2 采集详细日志
+#### 采集详细日志
 
 默认 `info` 级别只记录关键事件。当需要分析指令收发细节（如指令下发后实际状态未跟上），将级别调至 `debug` 获取 SDO/PDO 通信记录，或调至 `trace` 额外获取原始收发字节：
 

--- a/docs/external/zh/tutorial.mdx
+++ b/docs/external/zh/tutorial.mdx
@@ -3,10 +3,10 @@ title: 教程
 description: Wuji Hand SDK (wujihandpy) 教程，涵盖设备连接、同步/异步读写和实时控制的使用方法。
 ---
 
-## 1. 设备连接与筛选
+## 设备连接与筛选
 本节介绍如何在 wujihandpy 中连接灵巧手设备，以及在存在多台设备时进行筛选的方法。
 
-### 1.1 接口概述
+### 连接与筛选接口概述
 ```python
 class Hand:
     def __init__(
@@ -19,14 +19,14 @@ class Hand:
         ...
 ```
 
-### 1.2 连接设备
+### 连接设备
 调用 `wujihandpy.Hand()` 可创建一个 `Hand` 对象并连接灵巧手：
 ```python
 hand = wujihandpy.Hand()
 ```
 若系统中仅连接一台灵巧手，则会自动连接该设备。
 
-### 1.3 筛选设备
+### 筛选设备
 当系统中连接了多台灵巧手时，使用无参构造函数将导致错误。例如：
 ```
 [ERROR] 2 devices found with specified vendor id (0x0483)
@@ -66,7 +66,7 @@ SDK 会自动枚举所有匹配设备、读取每只手的手性标识，再连�
 - 同侧接入了两只 → 抛 `ConnectionError`，提示改用 `serial_number`
 </Callout>
 
-### 1.4 查询序列号
+### 查询序列号
 
 灵巧手有两种序列号：
 
@@ -96,9 +96,9 @@ print(product_sn)  # e.g. "WJ-DH5-R-2501001"
 ```
 
 
-## 2. 读取数据
+## 读取数据
 本节介绍如何以同步模式读取数据。
-### 2.1 接口概述
+### 读取接口概述
 调用 `read_*` 系列函数会向灵巧手发送同步读请求，并阻塞当前线程直到设备返回结果。函数返回则表示读取已成功完成。
 
 <Callout type="warning">
@@ -108,11 +108,11 @@ print(product_sn)  # e.g. "WJ-DH5-R-2501001"
 
   对实时控制场景，请考虑：
 
-  - 使用 [单向/双向实时控制器](#4-实时控制)
-  - 在旁路低速循环中使用 [异步 API](#5-异步读写)
+  - 使用 [单向/双向实时控制器](#实时控制)
+  - 在旁路低速循环中使用 [异步 API](#异步读写)
 </Callout>
 
-### 2.2 单值读取
+### 单值读取
 当读取层级与对象层级一致时，函数返回单个标量值。
 ```python
 class Hand:
@@ -135,7 +135,7 @@ time = hand.read_system_time()
 position = hand.finger(1).joint(0).read_joint_actual_position()
 ```
 
-### 2.3 批量读取
+### 批量读取
 当读取层级低于对象层级时，函数返回包含多个数据的矩阵。
 ```python
 class Hand:
@@ -168,13 +168,13 @@ positions = hand.read_joint_actual_position()
 [ 0.382  0.241 -0.003 -0.275]
 ```
 
-### 2.4 更多示例
+### 更多读取示例
 - [example/joint/1.read.py](https://github.com/wuji-technology/wujihandpy/blob/main/example/joint/1.read.py)
 
 
-## 3. 写入数据
+## 写入数据
 本节介绍如何以同步模式写入数据。
-### 3.1 接口概述
+### 写入接口概述
 调用 `write_*` 系列函数会向灵巧手发送同步写请求，并阻塞当前线程直到设备返回结果。函数返回则表示写入已成功完成。
 
 <Callout type="warning">
@@ -184,11 +184,11 @@ positions = hand.read_joint_actual_position()
 
   对实时控制场景，请考虑：
 
-  - 使用 [单向/双向实时控制器](#4-实时控制)
-  - 在旁路低速循环中使用 [异步 API](#5-异步读写)
+  - 使用 [单向/双向实时控制器](#实时控制)
+  - 在旁路低速循环中使用 [异步 API](#异步读写)
 </Callout>
 
-### 3.2 单值写入
+### 单值写入
 当写入层级与对象层级一致时，函数使用单个标量值。
 ```python
 class Hand:
@@ -207,7 +207,7 @@ class Joint:
 hand.finger(1).joint(0).write_joint_enabled(True)
 ```
 
-### 3.3 批量写入
+### 批量写入
 当写入层级低于对象层级时，函数既可使用单个标量值，也可使用包含多个数据的矩阵。
 ```python
 class Hand:
@@ -269,7 +269,7 @@ hand.write_joint_target_position(
 )
 ```
 
-### 3.4 非法数值写入
+### 非法数值写入
 
 通常，非法数值写入会被自动处理，例如：
 - 超出合法范围的角度会被自动限幅至上下界。
@@ -279,14 +279,14 @@ hand.write_joint_target_position(
 
 会导致操作失败，抛出 TimeoutError。
 
-### 3.5 更多示例
+### 更多写入示例
 - [example/joint/2.write.py](https://github.com/wuji-technology/wujihandpy/blob/main/example/joint/2.write.py)
 
 
-## 4. 实时控制
+## 实时控制
 本节介绍在 wujihandpy 中以实时模式控制灵巧手的方法。
 
-### 4.1 接口概述
+### 实时控制接口概述
 ```python
 class Hand:
     def realtime_controller(self, enable_upstream: bool, filter: filter.IFilter) -> IController:
@@ -306,7 +306,7 @@ class IController:
 调用 `Hand.realtime_controller()` 可使灵巧手进入实时控制模式，并返回一个实时控制器对象 `IController`。
 进入实时控制模式后，电机侧会启动一个 16 kHz 实时滤波器，将控制量滤波为平滑的 16 kHz 信号。
 
-### 4.2 滤波器
+### 滤波器
 实时控制器需要一个滤波器对象 (`filter.IFilter`) 来平滑地调整目标值。  
 <Callout type="info">
   滤波器的初值会自动设置为灵巧手的实际位置，避免初始过渡问题。
@@ -319,7 +319,7 @@ wujihandpy 提供以下常用滤波器：
   由于滤波器逻辑运行于电机驱动板上，不可使用自定义滤波器。
 </Callout>
 
-### 4.3 上下文管理器
+### 上下文管理器
 `IController` 可作为上下文管理器使用：
 
 ```python
@@ -334,13 +334,13 @@ with hand.realtime_controller(
 #### 自动析构
 若未使用上下文管理器，`IController` 在析构时也会自动调用 `close()`，由于 Python 的垃圾回收存在延迟，灵巧手可能不会立即退出实时模式。若不需精确控制退出时机，可直接依赖析构行为。
 
-### 4.4 实时写入
+### 实时写入
 ```python
 def set_joint_target_position(self, value_array: np.NDArray[np.float64]) -> None: ...
 ```
 `set_joint_target_position()` 函数会非阻塞地将目标控制量尽可能快地发送至电机驱动板。
 
-### 4.5 实时读取
+### 实时读取
 电机以 1 kHz 的频率自动上报当前位置和 effort。以下函数均为非阻塞调用，会立即返回缓存中最新的读取结果。
 
 ```python
@@ -381,14 +381,14 @@ finally:
     hand.write_joint_enabled(False)
 ```
 
-### 4.6 进阶示例
+### 实时控制进阶示例
 - [example/joint/3.realtime.py](https://github.com/wuji-technology/wujihandpy/blob/main/example/joint/3.realtime.py)
 
 
-## 5. 异步读/写
+## 异步读/写
 本节介绍在 wujihandpy 中以异步模式读/写数据的方法。
 
-### 5.1 接口概述
+### 异步接口概述
 读/写接口均提供异步版本，函数名以 `_async` 为后缀，用于在协程环境中执行非阻塞的 I/O 操作。
 ```python
 async def read_<dataname>_async(self) -> datatype: ...
@@ -409,8 +409,8 @@ async def write_<dataname>_async(self, values: np.NDArray[datatype]): ...  # 批
 
   对实时控制场景，请考虑：
 
-  - 使用 [单向/双向实时控制器](#4-实时控制)
-  - 在旁路低速循环中使用 [异步 API](#5-异步读写)
+  - 使用 [单向/双向实时控制器](#实时控制)
+  - 在旁路低速循环中使用 [异步 API](#异步读写)
 </Callout>
 
 **示例**
@@ -438,14 +438,14 @@ async def main():
 asyncio.run(main())
 ```
 
-### 5.2 进阶示例
+### 异步进阶示例
 - [example/joint/4.async.py](https://github.com/wuji-technology/wujihandpy/blob/main/example/joint/4.async.py)
 
 
-## 6. 多线程操作
+## 多线程操作
 本节介绍在 wujihandpy 中进行多线程操作的方法。
 
-### 6.1 接口概述
+### 多线程接口概述
 默认情况下，wujihandpy 会对 `Hand` 对象进行线程安全检查，以防止多线程并发访问导致的数据竞争问题。若需在多线程环境中使用同一个 `Hand` 对象，需先调用 `Hand.disable_thread_safe_check()` 禁用该检查。
 
 ```python
@@ -454,7 +454,7 @@ class Hand:
         ...
 ```
 
-### 6.2 多线程安全注意事项
+### 多线程安全注意事项
 
 <Callout type="warning">
 **重要**：禁用线程安全检查后，用户需要自行保证线程安全。
@@ -526,7 +526,7 @@ with hand.realtime_controller(
         t.join()
 ```
 
-### 6.3 预期效果
+### 预期效果
 
 运行示例后，终端将输出类似以下内容：
 
@@ -562,14 +562,14 @@ Thread safety check disabled, multi-threaded access enabled
 - 两个线程交替输出，顺序可能交错，这是多线程的正常现象
 - F1（拇指）保持不动，F2（食指）、F3（中指）、F4（无名指）、F5（小指）会做周期性弯曲-伸展动作
 
-### 6.4 进阶示例
+### 多线程进阶示例
 - [example/joint/5.multithread.py](https://github.com/wuji-technology/wujihandpy/blob/main/example/joint/5.multithread.py)
 
 
-## 7. USB 断连处理
+## USB 断连处理
 设备运行期间，灵巧手与电脑之间的 USB 连接可能中断，例如数据线被拔出。本节介绍 wujihandpy 在断连时的行为，以及捕获断连异常的方法。
 
-### 7.1 断连时的行为
+### 断连时的行为
 USB 连接中断时，wujihandpy 会抛出异常。捕获该异常即可在断连后恢复，进程不会崩溃。
 
 断连后再次发起的操作会立即抛出 Python 内置的 `ConnectionError`，不再等待 500 ms 超时，涉及接口包括：
@@ -581,7 +581,7 @@ USB 连接中断时，wujihandpy 会抛出异常。捕获该异常即可在断�
   断连瞬间已在等待中的异步请求是个例外：它会以 `TimeoutError` 结束，而非 `ConnectionError`。若代码中存在并发的异步操作，建议捕获两者的共同基类 `OSError`，即可同时覆盖断连与超时。
 </Callout>
 
-### 7.2 捕获断连异常
+### 捕获断连异常
 将设备操作放入 `try` 块，捕获 `ConnectionError` 即可处理断连：
 
 ```python
@@ -608,7 +608,7 @@ if __name__ == "__main__":
 
 运行脚本后，在读取过程中拔出 USB 线缆，循环会立即被 `ConnectionError` 中断，程序正常退出而不会崩溃。
 
-### 7.3 实时控制模式下的断连检测
+### 实时控制模式下的断连检测
 <Callout type="warning">
   实时控制器的非阻塞接口（`set_joint_target_position()`、`get_joint_actual_position()`、`get_joint_actual_effort()`）在断连时**不会**抛出 `ConnectionError`。
 </Callout>
@@ -617,5 +617,5 @@ if __name__ == "__main__":
 
 实时控制器以上下文管理器使用时，`with` 块结束会自动调用 `close()` 完成清理。断连状态下 `close()` 也会安全返回，无需额外处理。
 
-### 7.4 更多示例
+### 更多断连处理示例
 - [example/joint/6.disconnect.py](https://github.com/wuji-technology/wujihandpy/blob/main/example/joint/6.disconnect.py)


### PR DESCRIPTION
## Summary
文档三页（api-reference / introduction / tutorial）各级标题移除 1. / 2.1.5 式手工编号，层级与顺序由站点侧边栏和页内 TOC 呈现。

- zh/en 各 90 个标题去号，代码块内容未触碰
- 编号此前承担消歧功能的小节改为自明标题：tutorial 各章「接口概述 / 更多示例 / 进阶示例」并入章节语境（如「实时控制接口概述」「更多读取示例」），introduction 排障小节改「安装问题 / Installation Issues」「快速上手问题 / Quick Start Issues」
- 文内与跨页锚点链接同步更新（每语言 14 处），「教程 §1.3」式序号引用一并改为按标题名引用
- en 的 Multi-threaded / Multi-threading 标题统一为 Title Case（Multi-Threaded / Multi-Threading，slug 不变）

## Test plan
- github-slugger（文档站同款）静态验证受影响链接 38/38 解析成功
- 去号与改名后 h2-h4 标题唯一性校验通过，未链接的 h5 重复项维持现状
- 全站扫描确认站外入站链接仅一处（Wuji Hand 文档），已在对应 PR 同步更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 统一中英文 API 参考、入门指南和教程的标题层级，移除章节编号。
  * 更新文档内部链接与锚点，确保安装、快速开始、故障排查及 API 参考链接正常跳转。
  * 保持 API 签名、示例、操作流程和说明内容不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->